### PR TITLE
fix: removes extra sort added to ensure go compatibility

### DIFF
--- a/src/core/ls.js
+++ b/src/core/ls.js
@@ -77,18 +77,7 @@ module.exports = (ipfs) => {
         }
 
         return file
-      })),
-
-      // https://github.com/ipfs/go-ipfs/issues/5181
-      (files, cb) => {
-        if (options.long) {
-          return cb(null, files.sort((a, b) => {
-            return b.name.localeCompare(a.name)
-          }))
-        }
-
-        cb(null, files)
-      }
+      }))
     ], callback)
   }
 }


### PR DESCRIPTION
Previously we had to do the extra sort due to ipfs/go-ipfs#5181

Now that's been resolved & released we can remove it, yay!

License: MIT
Signed-off-by: achingbrain <alex@achingbrain.net>