### PR TITLE
Fix/err code

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/ipfs/js-ipfs-mfs#readme",
   "devDependencies": {
-    "aegir": "^15.0.0",
+    "aegir": "^15.2.0",
     "chai": "^4.1.2",
     "detect-node": "^2.0.3",
     "detect-webworker": "^1.0.0",
@@ -54,7 +54,7 @@
     "debug": "^3.1.0",
     "file-api": "~0.10.4",
     "filereader-stream": "^2.0.0",
-    "interface-datastore": "~0.4.2",
+    "interface-datastore": "~0.5.0",
     "ipfs-unixfs": "~0.1.15",
     "ipfs-unixfs-engine": "~0.32.1",
     "is-pull-stream": "~0.0.0",

--- a/src/core/utils/with-mfs-root.js
+++ b/src/core/utils/with-mfs-root.js
@@ -38,7 +38,8 @@ const withMfsRoot = (ipfs, callback) => {
           ], cb)
         }
 
-        cb(error, new CID(result))
+        const cid = result ? new CID(result) : null
+        cb(error, cid)
       })
     },
     // Turn the Buffer into a CID

--- a/src/core/utils/with-mfs-root.js
+++ b/src/core/utils/with-mfs-root.js
@@ -22,7 +22,7 @@ const withMfsRoot = (ipfs, callback) => {
     (cb) => {
       // Load the MFS root CID
       datastore.get(MFS_ROOT_KEY, (error, result) => {
-        if (error && error.notFound) {
+        if (error && error.code === 'ERR_NOT_FOUND') {
           log('Creating new MFS root')
 
           return waterfall([

--- a/src/core/utils/with-mfs-root.js
+++ b/src/core/utils/with-mfs-root.js
@@ -22,7 +22,8 @@ const withMfsRoot = (ipfs, callback) => {
     (cb) => {
       // Load the MFS root CID
       datastore.get(MFS_ROOT_KEY, (error, result) => {
-        if (error && error.code === 'ERR_NOT_FOUND') {
+        // Once datastore-level releases its error.code addition, we can remove error.notFound logic
+        if (error && (error.notFound || error.code === 'ERR_NOT_FOUND')) {
           log('Creating new MFS root')
 
           return waterfall([


### PR DESCRIPTION
Required by https://github.com/ipfs/js-ipfs/issues/1557

This leverages the upcoming update to interface-datastore, to use consistent error codes, in order to better handle `not found` errors from the various databases available to ipfs users. 

Once all the releases mentioned in js-ipfs#1557 are completed, all datastores will provide the same code when .get yields a not found error. 

I also added an additional check of the result so that we don't attempt to create a CID in the event that a different error is returned from the database and result is null/undefined.

~~**Note**: This is not dependent on any other PR, however, if users get this update and not the datastore-level update (or vice versa), https://github.com/ipfs/js-datastore-level/pull/10, they'll get an error if their mfs root doesnt exist yet.~~