### PR TITLE
fix: make sure hashes are the same after shard changes

### DIFF
--- a/src/core/utils/add-link.js
+++ b/src/core/utils/add-link.js
@@ -10,8 +10,10 @@ const DirSharded = require('ipfs-unixfs-importer/src/importer/dir-sharded')
 const series = require('async/series')
 const log = require('debug')('ipfs:mfs:core:utils:add-link')
 const UnixFS = require('ipfs-unixfs')
-const Bucket = require('hamt-sharding/src/bucket')
-const whilst = require('async/whilst')
+const {
+  generatePath,
+  updateHamtDirectory
+} = require('./hamt-utils')
 
 const defaultOptions = {
   parent: undefined,
@@ -104,18 +106,8 @@ const convertToShardedDirectory = (context, options, callback) => {
 
 const addToDirectory = (context, options, callback) => {
   waterfall([
-    (done) => {
-      if (options.name) {
-        // Remove the old link if necessary
-        return DAGNode.rmLink(options.parent, options.name, done)
-      }
-
-      done(null, options.parent)
-    },
-    (parent, done) => {
-      // Add the new link to the parent
-      DAGNode.addLink(parent, new DAGLink(options.name, options.size, options.cid), done)
-    },
+    (done) => DAGNode.rmLink(options.parent, options.name, done),
+    (parent, done) => DAGNode.addLink(parent, new DAGLink(options.name, options.size, options.cid), done),
     (parent, done) => {
       // Persist the new parent DAGNode
       context.ipld.put(parent, {
@@ -234,180 +226,6 @@ const updateShardParent = (context, bucket, parent, name, node, cid, prefix, opt
     (parent, done) => DAGNode.addLink(parent, new DAGLink(prefix, node.size, cid), done),
     (parent, done) => updateHamtDirectory(context, parent.links, bucket, options, done)
   ], callback)
-}
-
-const updateHamtDirectory = (context, links, bucket, options, callback) => {
-  // update parent with new bit field
-  waterfall([
-    (cb) => {
-      const data = Buffer.from(bucket._children.bitField().reverse())
-      const dir = new UnixFS('hamt-sharded-directory', data)
-      dir.fanout = bucket.tableSize()
-      dir.hashType = DirSharded.hashFn.code
-
-      DAGNode.create(dir.marshal(), links, cb)
-    },
-    (parent, done) => {
-      // Persist the new parent DAGNode
-      context.ipld.put(parent, {
-        version: options.cidVersion,
-        format: options.codec,
-        hashAlg: options.hashAlg,
-        hashOnly: !options.flush
-      }, (error, cid) => done(error, {
-        node: parent,
-        cid
-      }))
-    }
-  ], callback)
-}
-
-const recreateHamtLevel = (links, rootBucket, parentBucket, positionAtParent, callback) => {
-  // recreate this level of the HAMT
-  const bucket = new Bucket({
-    hashFn: DirSharded.hashFn,
-    hash: parentBucket ? parentBucket._options.hash : undefined
-  }, parentBucket, positionAtParent)
-
-  if (parentBucket) {
-    parentBucket._putObjectAt(positionAtParent, bucket)
-  }
-
-  addLinksToHamtBucket(links, bucket, rootBucket, callback)
-}
-
-const addLinksToHamtBucket = (links, bucket, rootBucket, callback) => {
-  Promise.all(
-    links.map(link => {
-      if (link.name.length === 2) {
-        const pos = parseInt(link.name, 16)
-
-        bucket._putObjectAt(pos, new Bucket({
-          hashFn: DirSharded.hashFn
-        }, bucket, pos))
-
-        return Promise.resolve()
-      }
-
-      return (rootBucket || bucket).put(link.name.substring(2), true)
-    })
-  )
-    .catch(err => {
-      callback(err)
-      callback = null
-    })
-    .then(() => callback && callback(null, bucket))
-}
-
-const toPrefix = (position) => {
-  return position
-    .toString('16')
-    .toUpperCase()
-    .padStart(2, '0')
-    .substring(0, 2)
-}
-
-const generatePath = (context, fileName, rootNode, callback) => {
-  // start at the root bucket and descend, loading nodes as we go
-  recreateHamtLevel(rootNode.links, null, null, null, async (err, rootBucket) => {
-    if (err) {
-      return callback(err)
-    }
-
-    const position = await rootBucket._findNewBucketAndPos(fileName)
-
-    // the path to the root bucket
-    let path = [{
-      bucket: position.bucket,
-      prefix: toPrefix(position.pos)
-    }]
-    let currentBucket = position.bucket
-
-    while (currentBucket !== rootBucket) {
-      path.push({
-        bucket: currentBucket,
-        prefix: toPrefix(currentBucket._posAtParent)
-      })
-
-      currentBucket = currentBucket._parent
-    }
-
-    path[path.length - 1].node = rootNode
-
-    let index = path.length
-
-    // load DAGNode for each path segment
-    whilst(
-      () => index > 0,
-      (next) => {
-        index--
-
-        const segment = path[index]
-
-        // find prefix in links
-        const link = segment.node.links
-          .filter(link => link.name.substring(0, 2) === segment.prefix)
-          .pop()
-
-        if (!link) {
-          // reached bottom of tree, file will be added to the current bucket
-          log(`Link ${segment.prefix}${fileName} will be added`)
-          return next(null, path)
-        }
-
-        if (link.name === `${segment.prefix}${fileName}`) {
-          log(`Link ${segment.prefix}${fileName} will be replaced`)
-          // file already existed, file will be added to the current bucket
-          return next(null, path)
-        }
-
-        // found subshard
-        log(`Found subshard ${segment.prefix}`)
-        context.ipld.get(link.cid, (err, result) => {
-          if (err) {
-            return next(err)
-          }
-
-          // subshard hasn't been loaded, descend to the next level of the HAMT
-          if (!path[index - 1]) {
-            log(`Loaded new subshard ${segment.prefix}`)
-            const node = result.value
-
-            return recreateHamtLevel(node.links, rootBucket, segment.bucket, parseInt(segment.prefix, 16), async (err, bucket) => {
-              if (err) {
-                return next(err)
-              }
-
-              const position = await rootBucket._findNewBucketAndPos(fileName)
-
-              index++
-              path.unshift({
-                bucket: position.bucket,
-                prefix: toPrefix(position.pos),
-                node: node
-              })
-
-              next()
-            })
-          }
-
-          const nextSegment = path[index - 1]
-
-          // add intermediate links to bucket
-          addLinksToHamtBucket(result.value.links, nextSegment.bucket, rootBucket, (error) => {
-            nextSegment.node = result.value
-
-            next(error)
-          })
-        })
-      },
-      async (err, path) => {
-        await rootBucket.put(fileName, true)
-
-        callback(err, { rootBucket, path })
-      }
-    )
-  })
 }
 
 module.exports = addLink

--- a/src/core/utils/add-link.js
+++ b/src/core/utils/add-link.js
@@ -10,7 +10,8 @@ const DirSharded = require('ipfs-unixfs-importer/src/importer/dir-sharded')
 const series = require('async/series')
 const log = require('debug')('ipfs:mfs:core:utils:add-link')
 const UnixFS = require('ipfs-unixfs')
-const Bucket = require('hamt-sharding')
+const Bucket = require('hamt-sharding/src/bucket')
+const loadNode = require('./load-node')
 
 const defaultOptions = {
   parent: undefined,
@@ -78,9 +79,27 @@ const addLink = (context, options, callback) => {
     return convertToShardedDirectory(context, options, callback)
   }
 
-  log('Adding to regular directory')
+  log(`Adding ${options.name} to regular directory`)
 
   addToDirectory(context, options, callback)
+}
+
+const convertToShardedDirectory = (context, options, callback) => {
+  createShard(context, options.parent.links.map(link => ({
+    name: link.name,
+    size: link.size,
+    multihash: link.cid.buffer
+  })).concat({
+    name: options.name,
+    size: options.size,
+    multihash: options.cid.buffer
+  }), {}, (err, result) => {
+    if (!err) {
+      log('Converted directory to sharded directory', result.cid.toBaseEncodedString())
+    }
+
+    callback(err, result)
+  })
 }
 
 const addToDirectory = (context, options, callback) => {
@@ -112,125 +131,116 @@ const addToDirectory = (context, options, callback) => {
   ], callback)
 }
 
-const addToShardedDirectory = async (context, options, callback) => {
-  const bucket = new Bucket({
-    hashFn: DirSharded.hashFn
-  })
-  const position = await bucket._findNewBucketAndPos(options.name)
-  const prefix = position.pos
+const addToShardedDirectory = (context, options, callback) => {
+  return waterfall([
+    (cb) => recreateHamtLevel(options.parent.links, cb),
+    (rootBucket, cb) => findPosition(options.name, rootBucket, (err, position) => cb(err, { rootBucket, position })),
+    ({ rootBucket, position }, cb) => {
+      // the path to the root bucket
+      let path = [{
+        position: position.pos,
+        bucket: position.bucket
+      }]
+      let currentBucket = position.bucket
+
+      while (currentBucket !== rootBucket) {
+        path.push({
+          bucket: currentBucket,
+          position: currentBucket._posAtParent
+        })
+
+        currentBucket = currentBucket._parent
+      }
+
+      cb(null, {
+        rootBucket,
+        path
+      })
+    },
+    ({ rootBucket, path }, cb) => updateShard(context, options.parent, rootBucket, path, {
+      name: options.name,
+      cid: options.cid,
+      size: options.size
+    }, options, (err, results = {}) => cb(err, { rootBucket, node: results.node })),
+    ({ rootBucket, node }, cb) => updateHamtDirectory(context, node.links, rootBucket, options, cb)
+  ], callback)
+}
+
+const updateShard = (context, parent, rootBucket, positions, child, options, callback) => {
+  const {
+    bucket,
+    position
+  } = positions.pop()
+
+  const prefix = position
     .toString('16')
     .toUpperCase()
     .padStart(2, '0')
     .substring(0, 2)
 
-  const existingSubShard = options.parent.links
-    .filter(link => link.name === prefix)
-    .pop()
+  const link = parent.links
+    .find(link => link.name.substring(0, 2) === prefix && link.name !== `${prefix}${child.name}`)
 
-  if (existingSubShard) {
-    log(`Descending into sub-shard ${prefix} to add link ${options.name}`)
+  return waterfall([
+    (cb) => {
+      if (link && link.name.length > 2) {
+        log(`Converting existing file ${link.name} into sub-shard for ${child.name}`)
 
-    return addLink(context, {
-      ...options,
-      parent: null,
-      parentCid: existingSubShard.cid
-    }, (err, { cid, node }) => {
-      if (err) {
-        return callback(err)
+        return waterfall([
+          (done) => createShard(context, [{
+            name: link.name.substring(2),
+            size: link.size,
+            multihash: link.cid.buffer
+          }, {
+            name: child.name,
+            size: child.size,
+            multihash: child.cid.buffer
+          }], {}, done),
+          ({ node: { links: [ shard ] } }, done) => {
+            return context.ipld.get(shard.cid, (err, result) => {
+              done(err, { cid: shard.cid, node: result && result.value })
+            })
+          },
+          ({ cid, node }, cb) => updateShardParent(context, bucket, parent, link.name, node, cid, prefix, options, cb)
+        ], cb)
       }
 
-      // make sure parent is updated with new sub-shard cid
-      addToDirectory(context, {
-        ...options,
-        parent: options.parent,
-        parentCid: options.parentCid,
-        name: prefix,
-        size: node.size,
-        cid: cid
-      }, callback)
-    })
-  }
+      if (link && link.name.length === 2) {
+        log(`Descending into sub-shard`, child.name)
 
-  const existingFile = options.parent.links
-    .filter(link => link.name.substring(2) === options.name)
-    .pop()
+        return waterfall([
+          (cb) => loadNode(context, link, cb),
+          ({ node }, cb) => {
+            Promise.all(
+              node.links.map(link => {
+                if (link.name.length === 2) {
+                  // add a bucket for the subshard of this subshard
+                  const pos = parseInt(link.name, 16)
 
-  if (existingFile) {
-    log(`Updating file ${existingFile.name}`)
+                  bucket._putObjectAt(pos, new Bucket({
+                    hashFn: DirSharded.hashFn
+                  }, bucket, pos))
 
-    return addToDirectory(context, {
-      ...options,
-      name: existingFile.name
-    }, callback)
-  }
+                  return Promise.resolve()
+                }
 
-  const existingUnshardedFile = options.parent.links
-    .filter(link => link.name.substring(0, 2) === prefix)
-    .pop()
-
-  if (existingUnshardedFile) {
-    log(`Replacing file ${existingUnshardedFile.name} with sub-shard`)
-
-    return createShard(context, [{
-      name: existingUnshardedFile.name.substring(2),
-      size: existingUnshardedFile.size,
-      multihash: existingUnshardedFile.cid.buffer
-    }, {
-      name: options.name,
-      size: options.size,
-      multihash: options.cid.buffer
-    }], {
-      root: false
-    }, (err, result) => {
-      if (err) {
-        return callback(err)
+                // add to the root and let changes cascade down
+                return rootBucket.put(link.name.substring(2), true)
+              })
+            )
+              .then(() => cb(null, { node }))
+              .catch(error => cb(error))
+          },
+          ({ node }, cb) => updateShard(context, node, bucket, positions, child, options, cb),
+          ({ cid, node }, cb) => updateShardParent(context, bucket, parent, link.name, node, cid, prefix, options, cb)
+        ], cb)
       }
 
-      const newShard = result.node.links[0]
+      log(`Adding or replacing file`, prefix + child.name)
 
-      waterfall([
-        (done) => DAGNode.rmLink(options.parent, existingUnshardedFile.name, done),
-        (parent, done) => DAGNode.addLink(parent, newShard, done),
-        (parent, done) => {
-          // Persist the new parent DAGNode
-          context.ipld.put(parent, {
-            version: options.cidVersion,
-            format: options.codec,
-            hashAlg: options.hashAlg,
-            hashOnly: !options.flush
-          }, (error, cid) => done(error, {
-            node: parent,
-            cid
-          }))
-        }
-      ], callback)
-    })
-  }
-
-  log(`Appending ${prefix + options.name} to shard`)
-
-  return addToDirectory(context, {
-    ...options,
-    name: prefix + options.name
-  }, callback)
-}
-
-const convertToShardedDirectory = (context, options, callback) => {
-  createShard(context, options.parent.links.map(link => ({
-    name: link.name,
-    size: link.size,
-    multihash: link.cid.buffer
-  })).concat({
-    name: options.name,
-    size: options.size,
-    multihash: options.cid.buffer
-  }), {}, (err, result) => {
-    if (!err) {
-      log('Converted directory to sharded directory', result.cid.toBaseEncodedString())
+      updateShardParent(context, bucket, parent, prefix + child.name, child, child.cid, prefix + child.name, options, cb)
     }
-
-    callback(err, result)
-  })
+  ], callback)
 }
 
 const createShard = (context, contents, options, callback) => {
@@ -265,6 +275,86 @@ const createShard = (context, contents, options, callback) => {
       shard.flush('', context.ipld, null, callback)
     }
   )
+}
+
+const updateShardParent = (context, bucket, parent, name, node, cid, prefix, options, callback) => {
+  waterfall([
+    (done) => {
+      if (name) {
+        if (name === prefix) {
+          log(`Updating link ${name} in shard parent`)
+        } else {
+          log(`Removing link ${name} from shard parent, adding link ${prefix}`)
+        }
+
+        return DAGNode.rmLink(parent, name, done)
+      }
+
+      log(`Adding link ${prefix} to shard parent`)
+      done(null, parent)
+    },
+    (parent, done) => DAGNode.addLink(parent, new DAGLink(prefix, node.size, cid), done),
+    (parent, done) => updateHamtDirectory(context, parent.links, bucket, options, done)
+  ], callback)
+}
+
+const updateHamtDirectory = (context, links, bucket, options, callback) => {
+  // update parent with new bit field
+  waterfall([
+    (cb) => {
+      const data = Buffer.from(bucket._children.bitField().reverse())
+      const dir = new UnixFS('hamt-sharded-directory', data)
+      dir.fanout = bucket.tableSize()
+      dir.hashType = DirSharded.hashFn.code
+
+      DAGNode.create(dir.marshal(), links, cb)
+    },
+    (parent, done) => {
+      // Persist the new parent DAGNode
+      context.ipld.put(parent, {
+        version: options.cidVersion,
+        format: options.codec,
+        hashAlg: options.hashAlg,
+        hashOnly: !options.flush
+      }, (error, cid) => done(error, {
+        node: parent,
+        cid
+      }))
+    }
+  ], callback)
+}
+
+const recreateHamtLevel = (links, callback) => {
+  // recreate this level of the HAMT
+  const bucket = new Bucket({
+    hashFn: DirSharded.hashFn
+  })
+
+  Promise.all(
+    links.map(link => {
+      if (link.name.length === 2) {
+        const pos = parseInt(link.name, 16)
+
+        bucket._putObjectAt(pos, new Bucket({
+          hashFn: DirSharded.hashFn
+        }, bucket, pos))
+
+        return Promise.resolve()
+      }
+
+      return bucket.put(link.name.substring(2), true)
+    })
+  )
+    .then(() => callback(null, bucket))
+    .catch(error => callback(error))
+}
+
+const findPosition = async (name, bucket, callback) => {
+  const position = await bucket._findNewBucketAndPos(name)
+
+  await bucket.put(name, true)
+
+  callback(null, position)
 }
 
 module.exports = addLink

--- a/src/core/utils/hamt-utils.js
+++ b/src/core/utils/hamt-utils.js
@@ -1,0 +1,193 @@
+'use strict'
+
+const {
+  DAGNode
+} = require('ipld-dag-pb')
+const waterfall = require('async/waterfall')
+const whilst = require('async/whilst')
+const Bucket = require('hamt-sharding/src/bucket')
+const DirSharded = require('ipfs-unixfs-importer/src/importer/dir-sharded')
+const log = require('debug')('ipfs:mfs:core:utils:hamt-utils')
+const UnixFS = require('ipfs-unixfs')
+
+const updateHamtDirectory = (context, links, bucket, options, callback) => {
+  // update parent with new bit field
+  waterfall([
+    (cb) => {
+      const data = Buffer.from(bucket._children.bitField().reverse())
+      const dir = new UnixFS('hamt-sharded-directory', data)
+      dir.fanout = bucket.tableSize()
+      dir.hashType = DirSharded.hashFn.code
+
+      DAGNode.create(dir.marshal(), links, cb)
+    },
+    (parent, done) => {
+      // Persist the new parent DAGNode
+      context.ipld.put(parent, {
+        version: options.cidVersion,
+        format: options.codec,
+        hashAlg: options.hashAlg,
+        hashOnly: !options.flush
+      }, (error, cid) => done(error, {
+        node: parent,
+        cid
+      }))
+    }
+  ], callback)
+}
+
+const recreateHamtLevel = (links, rootBucket, parentBucket, positionAtParent, callback) => {
+  // recreate this level of the HAMT
+  const bucket = new Bucket({
+    hashFn: DirSharded.hashFn,
+    hash: parentBucket ? parentBucket._options.hash : undefined
+  }, parentBucket, positionAtParent)
+
+  if (parentBucket) {
+    parentBucket._putObjectAt(positionAtParent, bucket)
+  }
+
+  addLinksToHamtBucket(links, bucket, rootBucket, callback)
+}
+
+const addLinksToHamtBucket = (links, bucket, rootBucket, callback) => {
+  Promise.all(
+    links.map(link => {
+      if (link.name.length === 2) {
+        const pos = parseInt(link.name, 16)
+
+        bucket._putObjectAt(pos, new Bucket({
+          hashFn: DirSharded.hashFn
+        }, bucket, pos))
+
+        return Promise.resolve()
+      }
+
+      return (rootBucket || bucket).put(link.name.substring(2), true)
+    })
+  )
+    .catch(err => {
+      callback(err)
+      callback = null
+    })
+    .then(() => callback && callback(null, bucket))
+}
+
+const toPrefix = (position) => {
+  return position
+    .toString('16')
+    .toUpperCase()
+    .padStart(2, '0')
+    .substring(0, 2)
+}
+
+const generatePath = (context, fileName, rootNode, callback) => {
+  // start at the root bucket and descend, loading nodes as we go
+  recreateHamtLevel(rootNode.links, null, null, null, async (err, rootBucket) => {
+    if (err) {
+      return callback(err)
+    }
+
+    const position = await rootBucket._findNewBucketAndPos(fileName)
+
+    // the path to the root bucket
+    let path = [{
+      bucket: position.bucket,
+      prefix: toPrefix(position.pos)
+    }]
+    let currentBucket = position.bucket
+
+    while (currentBucket !== rootBucket) {
+      path.push({
+        bucket: currentBucket,
+        prefix: toPrefix(currentBucket._posAtParent)
+      })
+
+      currentBucket = currentBucket._parent
+    }
+
+    path[path.length - 1].node = rootNode
+
+    let index = path.length
+
+    // load DAGNode for each path segment
+    whilst(
+      () => index > 0,
+      (next) => {
+        index--
+
+        const segment = path[index]
+
+        // find prefix in links
+        const link = segment.node.links
+          .filter(link => link.name.substring(0, 2) === segment.prefix)
+          .pop()
+
+        if (!link) {
+          // reached bottom of tree, file will be added to the current bucket
+          log(`Link ${segment.prefix}${fileName} will be added`)
+          return next(null, path)
+        }
+
+        if (link.name === `${segment.prefix}${fileName}`) {
+          log(`Link ${segment.prefix}${fileName} will be replaced`)
+          // file already existed, file will be added to the current bucket
+          return next(null, path)
+        }
+
+        // found subshard
+        log(`Found subshard ${segment.prefix}`)
+        context.ipld.get(link.cid, (err, result) => {
+          if (err) {
+            return next(err)
+          }
+
+          // subshard hasn't been loaded, descend to the next level of the HAMT
+          if (!path[index - 1]) {
+            log(`Loaded new subshard ${segment.prefix}`)
+            const node = result.value
+
+            return recreateHamtLevel(node.links, rootBucket, segment.bucket, parseInt(segment.prefix, 16), async (err, bucket) => {
+              if (err) {
+                return next(err)
+              }
+
+              const position = await rootBucket._findNewBucketAndPos(fileName)
+
+              index++
+              path.unshift({
+                bucket: position.bucket,
+                prefix: toPrefix(position.pos),
+                node: node
+              })
+
+              next()
+            })
+          }
+
+          const nextSegment = path[index - 1]
+
+          // add intermediate links to bucket
+          addLinksToHamtBucket(result.value.links, nextSegment.bucket, rootBucket, (error) => {
+            nextSegment.node = result.value
+
+            next(error)
+          })
+        })
+      },
+      async (err, path) => {
+        await rootBucket.put(fileName, true)
+
+        callback(err, { rootBucket, path })
+      }
+    )
+  })
+}
+
+module.exports = {
+  generatePath,
+  updateHamtDirectory,
+  recreateHamtLevel,
+  addLinksToHamtBucket,
+  toPrefix
+}

--- a/test/helpers/create-shard.js
+++ b/test/helpers/create-shard.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const pull = require('pull-stream/pull')
+const values = require('pull-stream/sources/values')
+const collect = require('pull-stream/sinks/collect')
+const importer = require('ipfs-unixfs-importer')
+const CID = require('cids')
+
+const createShard = (mfs, files, shardSplitThreshold = 10) => {
+  return new Promise((resolve, reject) => {
+    pull(
+      values(files),
+      importer(mfs.ipld, {
+        shardSplitThreshold,
+        reduceSingleLeafToSelf: false, // same as go-ipfs-mfs implementation, differs from `ipfs add`(!)
+        leafType: 'raw' // same as go-ipfs-mfs implementation, differs from `ipfs add`(!)
+      }),
+      collect((err, files) => {
+        if (err) {
+          return reject(files)
+        }
+
+        const dir = files[files.length - 1]
+
+        resolve(new CID(dir.multihash))
+      })
+    )
+  })
+}
+
+module.exports = createShard

--- a/test/helpers/create-sharded-directory.js
+++ b/test/helpers/create-sharded-directory.js
@@ -22,7 +22,9 @@ module.exports = async (mfs, shardSplitThreshold = 10, files = shardSplitThresho
         }))
       ),
       importer(mfs.ipld, {
-        shardSplitThreshold
+        shardSplitThreshold,
+        reduceSingleLeafToSelf: false, // same as go-ipfs-mfs implementation, differs from `ipfs add`(!)
+        leafType: 'raw' // same as go-ipfs-mfs implementation, differs from `ipfs add`(!)
       }),
       collect(async (err, files) => {
         if (err) {

--- a/test/helpers/create-sharded-directory.js
+++ b/test/helpers/create-sharded-directory.js
@@ -3,42 +3,18 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
-const crypto = require('crypto')
-const pull = require('pull-stream/pull')
-const values = require('pull-stream/sources/values')
-const collect = require('pull-stream/sinks/collect')
-const importer = require('ipfs-unixfs-importer')
-const CID = require('cids')
+const createShard = require('./create-shard')
 
 module.exports = async (mfs, shardSplitThreshold = 10, files = shardSplitThreshold) => {
   const dirPath = `/sharded-dir-${Math.random()}`
+  const cid = await createShard(mfs, new Array(files).fill(0).map((_, index) => ({
+    path: `${dirPath}/file-${index}`,
+    content: Buffer.from([0, 1, 2, 3, 4, 5, index])
+  })), shardSplitThreshold)
 
-  return new Promise((resolve, reject) => {
-    pull(
-      values(
-        new Array(files).fill(0).map((_, index) => ({
-          path: `${dirPath}/file-${index}`,
-          content: crypto.randomBytes(5)
-        }))
-      ),
-      importer(mfs.ipld, {
-        shardSplitThreshold,
-        reduceSingleLeafToSelf: false, // same as go-ipfs-mfs implementation, differs from `ipfs add`(!)
-        leafType: 'raw' // same as go-ipfs-mfs implementation, differs from `ipfs add`(!)
-      }),
-      collect(async (err, files) => {
-        if (err) {
-          return reject(files)
-        }
+  await mfs.cp(`/ipfs/${cid.toBaseEncodedString()}`, dirPath)
 
-        const dir = files[files.length - 1]
+  expect((await mfs.stat(dirPath)).type).to.equal('hamt-sharded-directory')
 
-        await mfs.cp(`/ipfs/${new CID(dir.multihash).toBaseEncodedString()}`, dirPath)
-
-        expect((await mfs.stat(dirPath)).type).to.equal('hamt-sharded-directory')
-
-        resolve(dirPath)
-      })
-    )
-  })
+  return dirPath
 }

--- a/test/helpers/create-two-shards.js
+++ b/test/helpers/create-two-shards.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const createShard = require('./create-shard')
+
+const createTwoShards = async (mfs, fileCount) => {
+  const shardSplitThreshold = 10
+  const dirPath = `/sharded-dir-${Math.random()}`
+  const files = new Array(fileCount).fill(0).map((_, index) => ({
+    path: `${dirPath}/file-${index}`,
+    content: Buffer.from([0, 1, 2, 3, 4, index])
+  }))
+  files[files.length - 1].path = `${dirPath}/file-${fileCount - 1}`
+
+  const allFiles = files.map(file => ({
+    ...file
+  }))
+  const someFiles = files.map(file => ({
+    ...file
+  }))
+  const nextFile = someFiles.pop()
+
+  const dirWithAllFiles = await createShard(mfs, allFiles, shardSplitThreshold)
+  const dirWithSomeFiles = await createShard(mfs, someFiles, shardSplitThreshold)
+
+  return {
+    nextFile,
+    dirWithAllFiles,
+    dirWithSomeFiles,
+    dirPath
+  }
+}
+
+module.exports = createTwoShards

--- a/test/helpers/find-tree-with-depth.js
+++ b/test/helpers/find-tree-with-depth.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const createShard = require('./create-shard')
+const printTree = require('./print-tree')
+
+// find specific hamt structure by brute force
+const findTreeWithDepth = async (mfs, children, depth) => {
+  for (let i = 0; i < 100000; i++) {
+    const files = new Array(i).fill(0).map((_, index) => ({
+      path: `foo/file-${index}`,
+      content: Buffer.from([0, 1, 2, 3, 4, index])
+    }))
+
+    const cid = await createShard(mfs, files)
+    const hasChildrenAtDepth = await findChildrenAtDepth(mfs, cid, children, depth)
+
+    if (hasChildrenAtDepth) {
+      await printTree(mfs, cid)
+
+      return cid
+    }
+  }
+}
+
+const load = async (mfs, cid) => {
+  return new Promise((resolve, reject) => {
+    mfs.ipld.get(cid, (err, res) => {
+      if (err) {
+        return reject(err)
+      }
+
+      resolve(res.value)
+    })
+  })
+}
+
+const findChildrenAtDepth = async (mfs, cid, children, depth, currentDepth = 0) => {
+  const node = await load(mfs, cid)
+  const fileLinks = node.links.filter(link => link.name)
+
+  if (currentDepth === depth && fileLinks.length >= children) {
+    return true
+  }
+
+  for (let i = 0; i < fileLinks.length; i++) {
+    const res = await findChildrenAtDepth(mfs, fileLinks[i].cid, children, depth, currentDepth + 1)
+
+    if (res) {
+      return true
+    }
+  }
+
+  return false
+}
+
+module.exports = findTreeWithDepth

--- a/test/helpers/find-tree-with-depth.js
+++ b/test/helpers/find-tree-with-depth.js
@@ -5,7 +5,7 @@ const printTree = require('./print-tree')
 
 // find specific hamt structure by brute force
 const findTreeWithDepth = async (mfs, children, depth) => {
-  for (let i = 0; i < 100000; i++) {
+  for (let i = 10; i < 100000; i++) {
     const files = new Array(i).fill(0).map((_, index) => ({
       path: `foo/file-${index}`,
       content: Buffer.from([0, 1, 2, 3, 4, index])

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -38,6 +38,7 @@ module.exports = {
   cidAtPath: require('./cid-at-path'),
   collectLeafCids: require('./collect-leaf-cids'),
   createShardedDirectory: require('./create-sharded-directory'),
+  printTree: require('./print-tree'),
   EMPTY_DIRECTORY_HASH: 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn',
   EMPTY_DIRECTORY_HASH_BASE32: 'bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354'
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -37,7 +37,10 @@ module.exports = {
   createMfs,
   cidAtPath: require('./cid-at-path'),
   collectLeafCids: require('./collect-leaf-cids'),
+  createShard: require('./create-shard'),
   createShardedDirectory: require('./create-sharded-directory'),
+  createTwoShards: require('./create-two-shards'),
+  findTreeWithDepth: require('./find-tree-with-depth'),
   printTree: require('./print-tree'),
   EMPTY_DIRECTORY_HASH: 'QmUNLLsPACCz1vLxQVkXqqLX5R1X345qqfHbsf67hvA3Nn',
   EMPTY_DIRECTORY_HASH_BASE32: 'bafybeiczsscdsbs7ffqz55asqdf3smv6klcw3gofszvwlyarci47bgf354'

--- a/test/helpers/print-tree.js
+++ b/test/helpers/print-tree.js
@@ -12,13 +12,15 @@ const load = async (cid, mfs) => {
   })
 }
 
-const printTree = async (cid, mfs, indentation = '', name = '') => {
+const printTree = async (mfs, cid, indentation = '', name = '') => {
   console.info(indentation, name, cid.toBaseEncodedString()) // eslint-disable-line no-console
 
   const node = await load(cid, mfs)
+  const fileLinks = node.links
+    .filter(link => link.name)
 
-  for (let i = 0; i < node.links.length; i++) {
-    await printTree(node.links[i].cid, mfs, `  ${indentation}`, node.links[i].name)
+  for (let i = 0; i < fileLinks.length; i++) {
+    await printTree(mfs, fileLinks[i].cid, `  ${indentation}`, fileLinks[i].name)
   }
 }
 

--- a/test/helpers/print-tree.js
+++ b/test/helpers/print-tree.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const load = async (cid, mfs) => {
+  return new Promise((resolve, reject) => {
+    mfs.ipld.get(cid, (err, res) => {
+      if (err) {
+        return reject(err)
+      }
+
+      resolve(res.value)
+    })
+  })
+}
+
+const printTree = async (cid, mfs, indentation = '', name = '') => {
+  console.info(indentation, name, cid.toBaseEncodedString()) // eslint-disable-line no-console
+
+  const node = await load(cid, mfs)
+
+  for (let i = 0; i < node.links.length; i++) {
+    await printTree(node.links[i].cid, mfs, `  ${indentation}`, node.links[i].name)
+  }
+}
+
+module.exports = printTree

--- a/test/rm.spec.js
+++ b/test/rm.spec.js
@@ -5,9 +5,11 @@ const chai = require('chai')
 chai.use(require('dirty-chai'))
 const expect = chai.expect
 const bufferStream = require('pull-buffer-stream')
+const CID = require('cids')
 const {
   createMfs,
-  createShardedDirectory
+  createShardedDirectory,
+  createTwoShards
 } = require('./helpers')
 const {
   FILE_SEPARATOR
@@ -247,19 +249,87 @@ describe('rm', function () {
     }
   })
 
-  it.skip('results in the same hash as a sharded directory created by the importer when removing a subshard', async () => {
+  it('results in the same hash as a sharded directory created by the importer when removing a file', async function () {
+    this.timeout(60000)
 
+    const {
+      nextFile,
+      dirWithAllFiles,
+      dirWithSomeFiles,
+      dirPath
+    } = await createTwoShards(mfs, 15)
+
+    await mfs.cp(`/ipfs/${dirWithAllFiles.toBaseEncodedString()}`, dirPath)
+
+    await mfs.rm(nextFile.path)
+
+    const stats = await mfs.stat(dirPath)
+    const updatedDirCid = new CID(stats.hash)
+
+    expect(stats.type).to.equal('hamt-sharded-directory')
+    expect(updatedDirCid.toBaseEncodedString()).to.deep.equal(dirWithSomeFiles.toBaseEncodedString())
   })
 
-  it.skip('results in the same hash as a sharded directory created by the importer when removing a file', async () => {
+  it('results in the same hash as a sharded directory created by the importer when removing a subshard', async function () {
+    this.timeout(60000)
 
+    const {
+      nextFile,
+      dirWithAllFiles,
+      dirWithSomeFiles,
+      dirPath
+    } = await createTwoShards(mfs, 31)
+
+    await mfs.cp(`/ipfs/${dirWithAllFiles.toBaseEncodedString()}`, dirPath)
+
+    await mfs.rm(nextFile.path)
+
+    const stats = await mfs.stat(dirPath)
+    const updatedDirCid = new CID(stats.hash)
+
+    expect(stats.type).to.equal('hamt-sharded-directory')
+    expect(updatedDirCid.toBaseEncodedString()).to.deep.equal(dirWithSomeFiles.toBaseEncodedString())
   })
 
-  it.skip('results in the same hash as a sharded directory created by the importer when removing a subshard of a subshard', async () => {
+  it('results in the same hash as a sharded directory created by the importer when removing a file from a subshard of a subshard', async function () {
+    this.timeout(60000)
 
+    const {
+      nextFile,
+      dirWithAllFiles,
+      dirWithSomeFiles,
+      dirPath
+    } = await createTwoShards(mfs, 2187)
+
+    await mfs.cp(`/ipfs/${dirWithAllFiles.toBaseEncodedString()}`, dirPath)
+
+    await mfs.rm(nextFile.path)
+
+    const stats = await mfs.stat(dirPath)
+    const updatedDirCid = new CID(stats.hash)
+
+    expect(stats.type).to.equal('hamt-sharded-directory')
+    expect(updatedDirCid.toBaseEncodedString()).to.deep.equal(dirWithSomeFiles.toBaseEncodedString())
   })
 
-  it.skip('results in the same hash as a sharded directory created by the importer when removing a file from a subshard of a subshard', async () => {
+  it('results in the same hash as a sharded directory created by the importer when removing a subshard of a subshard', async function () {
+    this.timeout(60000)
 
+    const {
+      nextFile,
+      dirWithAllFiles,
+      dirWithSomeFiles,
+      dirPath
+    } = await createTwoShards(mfs, 139)
+
+    await mfs.cp(`/ipfs/${dirWithAllFiles.toBaseEncodedString()}`, dirPath)
+
+    await mfs.rm(nextFile.path)
+
+    const stats = await mfs.stat(dirPath)
+    const updatedDirCid = new CID(stats.hash)
+
+    expect(stats.type).to.equal('hamt-sharded-directory')
+    expect(updatedDirCid.toBaseEncodedString()).to.deep.equal(dirWithSomeFiles.toBaseEncodedString())
   })
 })

--- a/test/rm.spec.js
+++ b/test/rm.spec.js
@@ -246,4 +246,20 @@ describe('rm', function () {
       expect(error.message).to.contain('does not exist')
     }
   })
+
+  it.skip('results in the same hash as a sharded directory created by the importer when removing a subshard', async () => {
+
+  })
+
+  it.skip('results in the same hash as a sharded directory created by the importer when removing a file', async () => {
+
+  })
+
+  it.skip('results in the same hash as a sharded directory created by the importer when removing a subshard of a subshard', async () => {
+
+  })
+
+  it.skip('results in the same hash as a sharded directory created by the importer when removing a file from a subshard of a subshard', async () => {
+
+  })
 })

--- a/test/stat.spec.js
+++ b/test/stat.spec.js
@@ -179,6 +179,6 @@ describe('stat', function () {
     const stats = await mfs.stat(`${shardedDirPath}/${files[0].name}`)
 
     expect(stats.type).to.equal('file')
-    expect(stats.size).to.equal(5)
+    expect(stats.size).to.equal(7)
   })
 })

--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -785,27 +785,9 @@ describe('write', function () {
     expect(actualBytes).to.deep.equal(expectedBytes)
   })
 
-  it('results in the same hash as a sharded directory created by the importer when creating a new subshard', async () => {
-    const {
-      nextFile,
-      dirWithAllFiles,
-      dirWithSomeFiles,
-      dirPath
-    } = await createTwoShards(mfs, 100)
+  it('results in the same hash as a sharded directory created by the importer when adding a new file', async function () {
+    this.timeout(60000)
 
-    await mfs.cp(`/ipfs/${dirWithSomeFiles.toBaseEncodedString()}`, dirPath)
-
-    await mfs.write(nextFile.path, nextFile.content, {
-      create: true
-    })
-
-    const stats = await mfs.stat(dirPath)
-    const updatedDirCid = new CID(stats.hash)
-
-    expect(updatedDirCid.toBaseEncodedString()).to.deep.equal(dirWithAllFiles.toBaseEncodedString())
-  })
-
-  it('results in the same hash as a sharded directory created by the importer when adding a new file', async () => {
     const {
       nextFile,
       dirWithAllFiles,
@@ -826,7 +808,31 @@ describe('write', function () {
     expect(updatedDirCid.toBaseEncodedString()).to.deep.equal(dirWithAllFiles.toBaseEncodedString())
   })
 
-  it('results in the same hash as a sharded directory created by the importer when adding a file to a subshard', async () => {
+  it('results in the same hash as a sharded directory created by the importer when creating a new subshard', async function () {
+    this.timeout(60000)
+
+    const {
+      nextFile,
+      dirWithAllFiles,
+      dirWithSomeFiles,
+      dirPath
+    } = await createTwoShards(mfs, 100)
+
+    await mfs.cp(`/ipfs/${dirWithSomeFiles.toBaseEncodedString()}`, dirPath)
+
+    await mfs.write(nextFile.path, nextFile.content, {
+      create: true
+    })
+
+    const stats = await mfs.stat(dirPath)
+    const updatedDirCid = new CID(stats.hash)
+
+    expect(updatedDirCid.toBaseEncodedString()).to.deep.equal(dirWithAllFiles.toBaseEncodedString())
+  })
+
+  it('results in the same hash as a sharded directory created by the importer when adding a file to a subshard', async function () {
+    this.timeout(60000)
+
     const {
       nextFile,
       dirWithAllFiles,
@@ -848,6 +854,8 @@ describe('write', function () {
   })
 
   it('results in the same hash as a sharded directory created by the importer when adding a file to a subshard of a subshard', async function () {
+    this.timeout(60000)
+
     const {
       nextFile,
       dirWithAllFiles,


### PR DESCRIPTION
Ensures hashes of sharded directories are the same after adding/removing nodes as if they'd been imported by the importer in their final state.

License: MIT
Signed-off-by: achingbrain <alex@achingbrain.net>