### PR TITLE
refactor: use ipld-in-memory module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "detect-webworker": "^1.0.0",
     "dirty-chai": "^2.0.1",
     "ipld": "~0.20.0",
+    "ipld-in-memory": "^2.0.0",
     "multihashes": "~0.4.14",
     "pull-buffer-stream": "^1.0.0",
     "pull-traverse": "^1.0.3"

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -4,7 +4,8 @@ const core = require('../../src/core')
 const isWebWorker = require('detect-webworker')
 const promisify = require('promisify-es6')
 const InMemoryDataStore = require('interface-datastore').MemoryDatastore
-const inMemoryIpld = promisify(require('ipld').inMemory)
+const Ipld = require('ipld')
+const inMemoryIpld = promisify(require('ipld-in-memory').bind(null, Ipld))
 
 const createMfs = async () => {
   let ipld = await inMemoryIpld()


### PR DESCRIPTION
The `inMemory` util is going away to remove dependence on IPFS. This PR switches to using the `ipld-in-memory` module which does the same thing.