### PR TITLE
[WIP] refactor: use getIpfs not ipfs from argv

### DIFF
--- a/src/cli/cp.js
+++ b/src/cli/cp.js
@@ -40,20 +40,21 @@ module.exports = {
     let {
       source,
       dest,
-      ipfs,
+      getIpfs,
       parents,
       format,
       hashAlg,
       shardSplitThreshold
     } = argv
 
-    argv.resolve(
-      ipfs.files.cp(source, dest, {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+      return ipfs.files.cp(source, dest, {
         parents,
         format,
         hashAlg,
         shardSplitThreshold
       })
-    )
+    })())
   }
 }

--- a/src/cli/flush.js
+++ b/src/cli/flush.js
@@ -14,11 +14,12 @@ module.exports = {
   handler (argv) {
     let {
       path,
-      ipfs
+      getIpfs
     } = argv
 
-    argv.resolve(
-      ipfs.files.flush(path || FILE_SEPARATOR, {})
-    )
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+      return ipfs.files.flush(path || FILE_SEPARATOR, {})
+    })())
   }
 }

--- a/src/cli/ls.js
+++ b/src/cli/ls.js
@@ -40,14 +40,15 @@ module.exports = {
   handler (argv) {
     let {
       path,
-      ipfs,
+      getIpfs,
       long,
       sort,
       cidBase
     } = argv
 
-    argv.resolve(
-      new Promise((resolve, reject) => {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+      return new Promise((resolve, reject) => {
         if (sort) {
           ipfs.files.ls(path || FILE_SEPARATOR, {
             long,
@@ -98,6 +99,6 @@ module.exports = {
           })
         )
       })
-    )
+    })())
   }
 }

--- a/src/cli/mkdir.js
+++ b/src/cli/mkdir.js
@@ -44,7 +44,7 @@ module.exports = {
   handler (argv) {
     let {
       path,
-      ipfs,
+      getIpfs,
       parents,
       cidVersion,
       hashAlg,
@@ -52,14 +52,16 @@ module.exports = {
       shardSplitThreshold
     } = argv
 
-    argv.resolve(
-      ipfs.files.mkdir(path, {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+
+      return ipfs.files.mkdir(path, {
         parents,
         cidVersion,
         hashAlg,
         flush,
         shardSplitThreshold
       })
-    )
+    })())
   }
 }

--- a/src/cli/mv.js
+++ b/src/cli/mv.js
@@ -35,18 +35,20 @@ module.exports = {
     let {
       source,
       dest,
-      ipfs,
+      getIpfs,
       parents,
       recursive,
       shardSplitThreshold
     } = argv
 
-    argv.resolve(
-      ipfs.files.mv(source, dest, {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+
+      return ipfs.files.mv(source, dest, {
         parents,
         recursive,
         shardSplitThreshold
       })
-    )
+    })())
   }
 }

--- a/src/cli/read.js
+++ b/src/cli/read.js
@@ -28,13 +28,15 @@ module.exports = {
   handler (argv) {
     let {
       path,
-      ipfs,
+      getIpfs,
       offset,
       length
     } = argv
 
-    argv.resolve(
-      new Promise((resolve, reject) => {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+
+      return new Promise((resolve, reject) => {
         pull(
           ipfs.files.readPullStream(path, {
             offset,
@@ -52,6 +54,6 @@ module.exports = {
           })
         )
       })
-    )
+    })())
   }
 }

--- a/src/cli/rm.js
+++ b/src/cli/rm.js
@@ -22,14 +22,16 @@ module.exports = {
   handler (argv) {
     let {
       path,
-      ipfs,
+      getIpfs,
       recursive
     } = argv
 
-    argv.resolve(
-      ipfs.files.rm(path, {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+
+      return ipfs.files.rm(path, {
         recursive
       })
-    )
+    })())
   }
 }

--- a/src/cli/stat.js
+++ b/src/cli/stat.js
@@ -51,15 +51,17 @@ Type: <type>`,
   handler (argv) {
     let {
       path,
-      ipfs,
+      getIpfs,
       format,
       hash,
       size,
       withLocal
     } = argv
 
-    argv.resolve(
-      ipfs.files.stat(path, {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+
+      return ipfs.files.stat(path, {
         withLocal
       })
         .then((stats) => {
@@ -79,6 +81,6 @@ Type: <type>`,
             .replace('<type>', stats.type)
           )
         })
-    )
+    })())
   }
 }

--- a/src/cli/write.js
+++ b/src/cli/write.js
@@ -89,7 +89,7 @@ module.exports = {
   handler (argv) {
     let {
       path,
-      ipfs,
+      getIpfs,
       offset,
       length,
       create,
@@ -106,8 +106,10 @@ module.exports = {
       shardSplitThreshold
     } = argv
 
-    argv.resolve(
-      ipfs.files.write(path, process.stdin, {
+    argv.resolve((async () => {
+      const ipfs = await getIpfs()
+
+      return ipfs.files.write(path, process.stdin, {
         offset,
         length,
         create,
@@ -123,6 +125,6 @@ module.exports = {
         flush,
         shardSplitThreshold
       })
-    )
+    })())
   }
 }


### PR DESCRIPTION
Using getIpfs gives the handlers the power to create an IPFS when needed instead of having to create it upfront for all handlers even if they don't use it. It allows operations like `echo "hello" | jsipfs add -q | jsipfs cid base32` to work without `jsipfs cid base32` failing because it's trying to acquire a repo lock when it doesn't use IPFS at all.