### PR TITLE
chore: pass callback as onFulfilled and onRejected

### DIFF
--- a/src/core/utils/create-lock.js
+++ b/src/core/utils/create-lock.js
@@ -37,19 +37,12 @@ module.exports = (repoOwner) => {
     })
       .then((result) => {
         log(`Finished ${type} operation`)
-        const cb = callback
-        callback = null
-        cb(null, result)
-      })
-      .catch((error) => {
+
+        callback(null, result)
+      }, (error) => {
         log(`Finished ${type} operation with error: ${error.message}`)
-        if (callback) {
-          return callback(error)
-        }
 
-        log(`Callback already invoked for ${type} operation`)
-
-        throw error
+        callback(error)
       })
   }
 

--- a/src/core/utils/hamt-utils.js
+++ b/src/core/utils/hamt-utils.js
@@ -66,11 +66,7 @@ const addLinksToHamtBucket = (links, bucket, rootBucket, callback) => {
       return (rootBucket || bucket).put(link.name.substring(2), true)
     })
   )
-    .catch(err => {
-      callback(err)
-      callback = null
-    })
-    .then(() => callback && callback(null, bucket))
+    .then(() => callback(null, bucket), callback)
 }
 
 const toPrefix = (position) => {

--- a/src/core/utils/remove-link.js
+++ b/src/core/utils/remove-link.js
@@ -91,11 +91,7 @@ const removeFromShardedDirectory = (context, options, callback) => {
     (cb) => generatePath(context, options.name, options.parent, cb),
     ({ rootBucket, path }, cb) => {
       rootBucket.del(options.name)
-        .catch(err => {
-          cb(err)
-          cb = null
-        })
-        .then(() => cb && cb(null, { rootBucket, path }))
+        .then(() => cb(null, { rootBucket, path }), cb)
     },
     ({ rootBucket, path }, cb) => {
       updateShard(context, path, {
@@ -142,11 +138,7 @@ const updateShard = (context, positions, child, options, callback) => {
           },
           (result, done) => {
             bucket.del(child.name)
-              .catch(err => {
-                done(err)
-                done = null
-              })
-              .then(() => done && done(null, result))
+              .then(() => done(null, result), done)
           },
           (result, done) => updateHamtDirectory(context, result.node.links, bucket, options, done)
         ], cb)


### PR DESCRIPTION
Previously we nulled out the reference to the callback and caught any error that was thrown - this isn't necessary as using the two-arg version of `Promise.then` means only one handler will be invoked, not both.