### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 Open an [issue](https://github.com/ipfs/js-ipfs-mfs/issues) or send a [PR](https://github.com/ipfs/js-ipfs-mfs/pulls) - see [CONTRIBUTING.md](./CONTRIBUTING.md) for how to make sure your branch is ready for PRing.
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 
 ## Changelog
 


### PR DESCRIPTION
commit bcdd40d14d7ff6f86e5d10edef27932d59540746 in the community repo renamed contributing.md to CONTRIBUTING.md.