### PR TITLE
fix: validate and coerce count param for read in HTTP API

### DIFF
--- a/src/http/read.js
+++ b/src/http/read.js
@@ -51,7 +51,8 @@ const mfsRead = {
       query: Joi.object().keys({
         arg: Joi.string().required(),
         offset: Joi.number().integer().min(0),
-        length: Joi.number().integer().min(0)
+        length: Joi.number().integer().min(0),
+        count: Joi.number().integer().min(0)
       })
         .rename('o', 'offset', {
           override: true,


### PR DESCRIPTION
When using the legacy `count` param, it's value wasn't being validated or coerced into an integer from a string.

It meant that a call to `http://localhost:5001/api/v0/files/read?offset=0&count=4096&arg=/gif/515f726a7087d.jpg&stream-channels=true` would produce a `count` value of `"4096"` and cause MFS to read the whole file!

There should probably be some better validation at the exporter level too.