### PR TITLE
refactor: use unixfs exporter with CID instances

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "interface-datastore": "~0.6.0",
     "ipfs-multipart": "~0.1.0",
     "ipfs-unixfs": "~0.1.16",
-    "ipfs-unixfs-exporter": "github:ipfs/js-ipfs-unixfs-exporter#refactor/export-cid-instances",
+    "ipfs-unixfs-exporter": "~0.36.0",
     "ipfs-unixfs-importer": "~0.38.0",
     "ipld-dag-pb": "~0.15.2",
     "is-pull-stream": "~0.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "interface-datastore": "~0.6.0",
     "ipfs-multipart": "~0.1.0",
     "ipfs-unixfs": "~0.1.16",
-    "ipfs-unixfs-exporter": "~0.35.5",
+    "ipfs-unixfs-exporter": "github:ipfs/js-ipfs-unixfs-exporter#refactor/export-cid-instances",
     "ipfs-unixfs-importer": "~0.38.0",
     "ipld-dag-pb": "~0.15.2",
     "is-pull-stream": "~0.0.0",

--- a/src/core/ls-pull-stream.js
+++ b/src/core/ls-pull-stream.js
@@ -103,7 +103,7 @@ module.exports = (context) => {
               }
 
               loadNode(context, {
-                cid: file.hash
+                cid: file.cid
               }, (err, result) => {
                 if (err) {
                   return cb(err)
@@ -114,7 +114,7 @@ module.exports = (context) => {
                 cb(null, {
                   name: file.name,
                   type: FILE_TYPES[meta.type],
-                  hash: formatCid(file.hash, options.cidBase),
+                  hash: formatCid(file.cid, options.cidBase),
                   size: meta.fileSize() || 0
                 })
               })

--- a/src/core/mkdir.js
+++ b/src/core/mkdir.js
@@ -8,7 +8,6 @@ const pull = require('pull-stream/pull')
 const filter = require('pull-stream/throughs/filter')
 const map = require('pull-stream/throughs/map')
 const collect = require('pull-stream/sinks/collect')
-const CID = require('cids')
 const {
   createNode,
   toMfsPath,
@@ -88,7 +87,7 @@ module.exports = (context) => {
             exported = currentPath
 
             return {
-              cid: new CID(node.hash),
+              cid: node.cid,
               name: node.name
             }
           }),

--- a/src/core/stat.js
+++ b/src/core/stat.js
@@ -11,7 +11,6 @@ const pull = require('pull-stream/pull')
 const collect = require('pull-stream/sinks/collect')
 const asyncMap = require('pull-stream/throughs/async-map')
 const exporter = require('ipfs-unixfs-exporter')
-const CID = require('cids')
 const log = require('debug')('ipfs:mfs:stat')
 
 const defaultOptions = {
@@ -43,7 +42,7 @@ module.exports = (context) => {
           asyncMap((file, cb) => {
             if (options.hash) {
               return cb(null, {
-                hash: formatCid(new CID(file.hash), options.cidBase)
+                hash: formatCid(file.cid, options.cidBase)
               })
             }
 
@@ -54,7 +53,7 @@ module.exports = (context) => {
             }
 
             loadNode(context, {
-              cid: file.hash
+              cid: file.cid
             }, (err, result) => {
               if (err) {
                 return cb(err)

--- a/src/core/utils/to-trail.js
+++ b/src/core/utils/to-trail.js
@@ -7,7 +7,6 @@ const filter = require('pull-stream/throughs/filter')
 const map = require('pull-stream/throughs/map')
 const collect = require('pull-stream/sinks/collect')
 const log = require('debug')('ipfs:mfs:utils:to-trail')
-const CID = require('cids')
 
 const toTrail = (context, path, options, callback) => {
   const toExport = toPathComponents(path)
@@ -57,7 +56,7 @@ const toTrail = (context, path, options, callback) => {
 
       return {
         name,
-        cid: new CID(node.hash),
+        cid: node.cid,
         size: node.size,
         type: node.type
       }


### PR DESCRIPTION
Allows MFS to use the unixfs exporter that exports CID instances without API changes.

refs https://github.com/ipfs/interface-js-ipfs-core/issues/394

Depends on:

* [x] https://github.com/ipfs/js-ipfs-unixfs-exporter/pull/19