### PR TITLE
fix: correct hamt structure when modifying deep sub-shards

### DIFF
--- a/test/helpers/create-shard.js
+++ b/test/helpers/create-shard.js
@@ -17,7 +17,7 @@ const createShard = (ipld, files, shardSplitThreshold = 10) => {
       }),
       collect((err, files) => {
         if (err) {
-          return reject(files)
+          return reject(err)
         }
 
         const dir = files[files.length - 1]


### PR DESCRIPTION
If you have a shard like:

```
F1
  A0
    C8myfile
```

And you add a file that causes `C8myfile` to become a subshard, previously you would end up with this:

```
F1
  A0
    C8
      C8
        B3myfile
        82newfile
```

This PR ensures you get the correct structure:

```
F1
  A0
    C8
      B3myfile
      82newfile
```

When we update a shard, we re-create a portion of the shard in order to update the existing structure, this avoids loading the entire shard which could be expensive.  Previously we weren't descending into the newly created sub-shard to add the correct portion to the existing shard.

Fixes #45