### PR TITLE
fix: handle shard updates that create subshards of subshards

### DIFF
--- a/test/write.spec.js
+++ b/test/write.spec.js
@@ -932,4 +932,51 @@ describe('write', () => {
       expect(err.message).to.contain('not exist')
     }
   })
+
+  it('adds files that cause sub-sub-shards to be created', async function () {
+    // this.timeout(60000)
+
+    const dir = `/updated-dir-${Date.now()}`
+    const buf = Buffer.from([0, 1, 2, 3, 4])
+
+    const dirCid = await createShard(mfs.ipld, [{
+      path: `${dir}/file-699.txt`,
+      content: buf
+    }], 1)
+
+    await mfs.cp(`/ipfs/${dirCid.toBaseEncodedString()}`, dir)
+
+    await mfs.write(`${dir}/file-1011.txt`, buf, {
+      create: true
+    })
+
+    await mfs.stat(`${dir}/file-1011.txt`)
+
+    expect(await mfs.read(`${dir}/file-1011.txt`)).to.deep.equal(buf)
+  })
+
+  it('removes files that cause sub-sub-shards to be removed', async function () {
+    this.timeout(60000)
+
+    const dir = `/imported-dir-${Date.now()}`
+    const buf = Buffer.from([0, 1, 2, 3, 4])
+
+    const dirCid = await createShard(mfs.ipld, [{
+      path: `${dir}/file-699.txt`,
+      content: buf
+    }, {
+      path: `${dir}/file-1011.txt`,
+      content: buf
+    }], 1)
+
+    await mfs.cp(`/ipfs/${dirCid.toBaseEncodedString()}`, dir)
+
+    await mfs.rm(`${dir}/file-1011.txt`)
+
+    try {
+      await mfs.stat(`${dir}/file-1011.txt`)
+    } catch (err) {
+      expect(err.message).to.contain('not exist')
+    }
+  })
 })


### PR DESCRIPTION
I'd assumed that adding a file to a HAMT shard involved either adding a link, updating a link or replacing a link with a subshard that contains the files.

You can have files that result in a subshard being created that contains a subshard with the files in.

This PR handles that outcome.