### PR TITLE
feat: handle raw nodes in mfs

### DIFF
--- a/src/core/ls-pull-stream.js
+++ b/src/core/ls-pull-stream.js
@@ -109,6 +109,15 @@ module.exports = (context) => {
                   return cb(err)
                 }
 
+                if (Buffer.isBuffer(result.node)) {
+                  return cb(null, {
+                    name: file.name,
+                    type: 0,
+                    hash: formatCid(file.cid, options.cidBase),
+                    size: result.node.length
+                  })
+                }
+
                 const meta = UnixFs.unmarshal(result.node.data)
 
                 cb(null, {

--- a/src/core/stat.js
+++ b/src/core/stat.js
@@ -63,6 +63,19 @@ module.exports = (context) => {
                 node, cid
               } = result
 
+              if (Buffer.isBuffer(node)) {
+                return cb(null, {
+                  hash: formatCid(cid, options.cidBase),
+                  size: node.length,
+                  cumulativeSize: node.length,
+                  blocks: 0,
+                  type: 'file', // really?
+                  local: undefined,
+                  sizeLocal: undefined,
+                  withLocality: false
+                })
+              }
+
               const meta = unmarshal(node.data)
               let blocks = node.links.length
 


### PR DESCRIPTION
Right now we can only `ls` and `stat` `dag-pb` nodes - this PR allows us to handle `raw` nodes when `stat`ing and `ls`ing IPFS paths.