### PR TITLE
fix: return the CID for dag-cbor nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "joi": "^14.3.0",
     "joi-browser": "^13.4.0",
     "mortice": "^1.2.1",
-    "multicodec": "~0.5.1",
+    "multicodec": "~0.5.3",
     "multihashes": "~0.4.14",
     "once": "^1.4.0",
     "promisify-es6": "^1.0.3",

--- a/src/core/stat.js
+++ b/src/core/stat.js
@@ -86,5 +86,13 @@ const statters = {
       sizeLocal: undefined,
       withLocality: false
     }
+  },
+  'dag-cbor': (file) => {
+    return {
+      cid: file.cid,
+      local: undefined,
+      sizeLocal: undefined,
+      withLocality: false
+    }
   }
 }

--- a/test/stat.spec.js
+++ b/test/stat.spec.js
@@ -7,6 +7,7 @@ const expect = chai.expect
 const crypto = require('crypto')
 const createMfs = require('./helpers/create-mfs')
 const createShardedDirectory = require('./helpers/create-sharded-directory')
+const mc = require('multicodec')
 
 describe('stat', () => {
   let mfs
@@ -159,5 +160,16 @@ describe('stat', () => {
 
     expect(stats.type).to.equal('file')
     expect(stats.size).to.equal(7)
+  })
+
+  it('stats a dag-cbor node', async () => {
+    const path = '/cbor.node'
+    const node = {}
+    const cid = await mfs.ipld.put(node, mc.getNumber('dag-cbor'))
+    await mfs.cp(`/ipfs/${cid}`, path)
+
+    const stats = await mfs.stat(path)
+
+    expect(stats.cid.toString()).to.equal(cid.toString())
   })
 })


### PR DESCRIPTION
Doesn't do much as I'm not really sure what we should return for the fields, but at least it doesn't error out now.