### PR TITLE
chore: update hapi deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "src/index.js",
   "browser": {
     "fs": false,
-    "joi": "joi-browser"
+    "@hapi/joi": "joi-browser"
   },
   "scripts": {
     "test": "aegir test",
@@ -51,8 +51,9 @@
     "temp-write": "^3.4.0"
   },
   "dependencies": {
+    "@hapi/boom": "^7.4.2",
+    "@hapi/joi": "^15.1.0",
     "async-iterator-last": "^1.0.0",
-    "boom": "^7.2.0",
     "cids": "~0.7.1",
     "debug": "^4.1.0",
     "err-code": "^1.1.2",
@@ -63,7 +64,6 @@
     "ipfs-unixfs-exporter": "~0.37.6",
     "ipfs-unixfs-importer": "~0.39.9",
     "ipld-dag-pb": "~0.17.2",
-    "joi": "^14.3.0",
     "joi-browser": "^13.4.0",
     "mortice": "^1.2.1",
     "multicodec": "~0.5.3",

--- a/src/http/cp.js
+++ b/src/http/cp.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 const mfsCp = {
   method: 'POST',

--- a/src/http/flush.js
+++ b/src/http/flush.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 const mfsFlush = {
   method: 'POST',

--- a/src/http/ls.js
+++ b/src/http/ls.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const {
   PassThrough
 } = require('stream')

--- a/src/http/mkdir.js
+++ b/src/http/mkdir.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 const mfsMkdir = {
   method: 'POST',

--- a/src/http/mv.js
+++ b/src/http/mv.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 const mfsMv = {
   method: 'POST',

--- a/src/http/read.js
+++ b/src/http/read.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const {
   PassThrough
 } = require('stream')

--- a/src/http/rm.js
+++ b/src/http/rm.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 const mfsRm = {
   method: 'POST',

--- a/src/http/stat.js
+++ b/src/http/stat.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 
 const mfsStat = {
   method: 'POST',

--- a/src/http/write.js
+++ b/src/http/write.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const Joi = require('joi')
+const Joi = require('@hapi/joi')
 const multipart = require('ipfs-multipart')
-const Boom = require('boom')
+const Boom = require('@hapi/boom')
 
 const mfsWrite = {
   method: 'POST',


### PR DESCRIPTION
They moved to `@hapi` namespace and now spew warnings on npm install.

resolves #54
refs https://github.com/ipfs/js-ipfs/issues/2225