### PR TITLE
chore: upgrade mortice to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "ipfs-unixfs-importer": "~0.40.0",
     "ipld-dag-pb": "~0.18.0",
     "joi-browser": "^13.4.0",
-    "mortice": "^1.2.1",
+    "mortice": "^2.0.0",
     "multicodec": "~0.5.3",
     "multihashes": "~0.4.14",
     "once": "^1.4.0",

--- a/src/core/utils/create-lock.js
+++ b/src/core/utils/create-lock.js
@@ -18,18 +18,26 @@ module.exports = (repoOwner) => {
 
   lock = {
     readLock: (func) => {
-      return (...args) => {
-        return mutex.readLock(() => {
-          return func.apply(null, args)
-        })
+      return async (...args) => {
+        const releaseLock = await mutex.readLock()
+
+        try {
+          return await func.apply(null, args)
+        } finally {
+          releaseLock()
+        }
       }
     },
 
     writeLock: (func) => {
-      return (...args) => {
-        return mutex.writeLock(() => {
-          return func.apply(null, args)
-        })
+      return async (...args) => {
+        const releaseLock = await mutex.writeLock()
+
+        try {
+          return await func.apply(null, args)
+        } finally {
+          releaseLock()
+        }
       }
     }
   }


### PR DESCRIPTION
Will need backporting to the 0.12.x branch to get `ipfs/js-ipfs#2379` into `v0.38.0`