### PR TITLE
fix: response for empty dir when ?stream=true

### DIFF
--- a/src/http/ls.js
+++ b/src/http/ls.js
@@ -35,26 +35,19 @@ const mfsLs = {
           cidBase
         })
 
-        let passThrough
+        const passThrough = new PassThrough()
 
         readableStream.on('data', (entry) => {
-          if (!passThrough) {
-            passThrough = new PassThrough()
-            resolve(passThrough)
-          }
-
+          resolve(passThrough)
           passThrough.write(JSON.stringify(mapEntry(entry)) + '\n')
         })
 
         readableStream.once('end', (entry) => {
-          if (passThrough) {
-            passThrough.end(entry ? JSON.stringify(mapEntry(entry)) + '\n' : undefined)
-          }
+          resolve(passThrough)
+          passThrough.end(entry ? JSON.stringify(mapEntry(entry)) + '\n' : undefined)
         })
 
-        readableStream.once('error', (error) => {
-          reject(error)
-        })
+        readableStream.once('error', reject)
       })
 
       return h.response(responseStream).header('X-Stream-Output', '1')


### PR DESCRIPTION
The new `ipfs-http-client` sets the `stream` option by default. When enabled, the MFS HTTP API [fails this test](https://github.com/ipfs/interface-js-ipfs-core/blob/c766dbff654fd259f7094070ee71858091898750/src/files-mfs/ls.js#L106-L112) because it waits for the first item before sending a response. Since no items are yielded and the stream ends it waits forever.