### PR TITLE
fix: remove format and/or codec options

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ipfs-multipart": "^0.3.0",
     "ipfs-unixfs": "^0.3.0",
     "ipfs-unixfs-exporter": "^0.40.0",
-    "ipfs-unixfs-importer": "^0.43.0",
+    "ipfs-unixfs-importer": "^0.43.1",
     "ipfs-utils": "^0.4.2",
     "ipld-dag-pb": "^0.18.0",
     "it-last": "^1.0.1",

--- a/src/cli/chmod.js
+++ b/src/cli/chmod.js
@@ -27,12 +27,6 @@ module.exports = {
       coerce: asBoolean,
       describe: 'Whether to change modes recursively'
     },
-    codec: {
-      alias: 'c',
-      type: 'string',
-      default: 'dag-pb',
-      describe: 'If intermediate directories are created, use this codec to create them (experimental)'
-    },
     'hash-alg': {
       alias: 'h',
       type: 'string',
@@ -59,7 +53,6 @@ module.exports = {
       mode,
       getIpfs,
       recursive,
-      codec,
       hashAlg,
       flush,
       shardSplitThreshold
@@ -70,7 +63,6 @@ module.exports = {
 
       return ipfs.files.chmod(path, mode, {
         recursive,
-        format: codec,
         hashAlg,
         flush,
         shardSplitThreshold

--- a/src/cli/cp.js
+++ b/src/cli/cp.js
@@ -17,12 +17,6 @@ module.exports = {
       coerce: asBoolean,
       describe: 'Create any non-existent intermediate directories'
     },
-    codec: {
-      alias: 'c',
-      type: 'string',
-      default: 'dag-pb',
-      describe: 'If intermediate directories are created, use this codec to create them (experimental)'
-    },
     'hash-alg': {
       alias: 'h',
       type: 'string',
@@ -49,7 +43,6 @@ module.exports = {
       dest,
       getIpfs,
       parents,
-      codec,
       flush,
       hashAlg,
       shardSplitThreshold
@@ -59,7 +52,6 @@ module.exports = {
       const ipfs = await getIpfs()
       return ipfs.files.cp(source, dest, {
         parents,
-        format: codec,
         flush,
         hashAlg,
         shardSplitThreshold

--- a/src/cli/mkdir.js
+++ b/src/cli/mkdir.js
@@ -25,12 +25,6 @@ module.exports = {
       default: 0,
       describe: 'Cid version to use. (experimental).'
     },
-    codec: {
-      alias: 'c',
-      type: 'string',
-      default: 'dag-pb',
-      describe: 'If intermediate directories are created, use this codec to create them (experimental)'
-    },
     'hash-alg': {
       alias: 'h',
       type: 'string',
@@ -67,7 +61,6 @@ module.exports = {
       getIpfs,
       parents,
       cidVersion,
-      codec,
       hashAlg,
       flush,
       shardSplitThreshold,
@@ -81,7 +74,6 @@ module.exports = {
       return ipfs.files.mkdir(path, {
         parents,
         cidVersion,
-        format: codec,
         hashAlg,
         flush,
         shardSplitThreshold,

--- a/src/cli/mv.js
+++ b/src/cli/mv.js
@@ -30,12 +30,6 @@ module.exports = {
       default: 0,
       describe: 'Cid version to use. (experimental).'
     },
-    codec: {
-      alias: 'c',
-      type: 'string',
-      default: 'dag-pb',
-      describe: 'If intermediate directories are created, use this codec to create them (experimental)'
-    },
     'hash-alg': {
       alias: 'h',
       type: 'string',
@@ -64,7 +58,6 @@ module.exports = {
       parents,
       recursive,
       cidVersion,
-      codec,
       hashAlg,
       flush,
       shardSplitThreshold
@@ -77,7 +70,6 @@ module.exports = {
         parents,
         recursive,
         cidVersion,
-        format: codec,
         hashAlg,
         flush,
         shardSplitThreshold

--- a/src/cli/touch.js
+++ b/src/cli/touch.js
@@ -31,12 +31,6 @@ module.exports = {
       default: 0,
       describe: 'Cid version to use. (experimental).'
     },
-    codec: {
-      alias: 'c',
-      type: 'string',
-      default: 'dag-pb',
-      describe: 'If intermediate directories are created, use this codec to create them (experimental)'
-    },
     'hash-alg': {
       alias: 'h',
       type: 'string',
@@ -56,7 +50,6 @@ module.exports = {
       getIpfs,
       flush,
       cidVersion,
-      codec,
       hashAlg,
       shardSplitThreshold,
       mtime
@@ -69,7 +62,6 @@ module.exports = {
         mtime,
         flush,
         cidVersion,
-        format: codec,
         hashAlg,
         shardSplitThreshold
       })

--- a/src/cli/write.js
+++ b/src/cli/write.js
@@ -78,11 +78,6 @@ module.exports = {
       type: 'string',
       default: 'sha2-256'
     },
-    codec: {
-      alias: ['c'],
-      type: 'string',
-      default: 'dag-pb'
-    },
     'shard-split-threshold': {
       type: 'number',
       default: 1000,
@@ -114,7 +109,6 @@ module.exports = {
       reduceSingleLeafToSelf,
       cidVersion,
       hashAlg,
-      codec,
       parents,
       progress,
       strategy,
@@ -136,7 +130,6 @@ module.exports = {
         reduceSingleLeafToSelf,
         cidVersion,
         hashAlg,
-        format: codec,
         parents,
         progress,
         strategy,

--- a/src/core/chmod.js
+++ b/src/core/chmod.js
@@ -16,7 +16,6 @@ const mh = require('multihashes')
 const defaultOptions = {
   flush: true,
   shardSplitThreshold: 1000,
-  format: 'dag-pb',
   hashAlg: 'sha2-256',
   cidVersion: 0,
   recursive: false
@@ -174,7 +173,7 @@ module.exports = (context) => {
 
     const updatedCid = await context.ipld.put(node, mc.DAG_PB, {
       cidVersion: cid.version,
-      hashAlg: mh.names['sha2-256'],
+      hashAlg: mh.names[options.hashAlg],
       onlyHash: !options.flush
     })
 
@@ -188,8 +187,7 @@ module.exports = (context) => {
       cid: updatedCid,
       size: node.serialize().length,
       flush: options.flush,
-      format: 'dag-pb',
-      hashAlg: 'sha2-256',
+      hashAlg: options.hashAlg,
       cidVersion: cid.version
     })
 

--- a/src/core/cp.js
+++ b/src/core/cp.js
@@ -15,7 +15,6 @@ const toTrail = require('./utils/to-trail')
 const defaultOptions = {
   parents: false,
   flush: true,
-  format: 'dag-pb',
   hashAlg: 'sha2-256',
   cidVersion: 0,
   shardSplitThreshold: 1000
@@ -150,7 +149,6 @@ const addSourceToParent = async (context, source, childName, parent, options) =>
     size: sourceBlock.data.length,
     cid: source.cid,
     name: childName,
-    format: options.format,
     hashAlg: options.hashAlg,
     cidVersion: options.cidVersion,
     flush: options.flush

--- a/src/core/mkdir.js
+++ b/src/core/mkdir.js
@@ -19,7 +19,6 @@ const defaultOptions = {
   hashAlg: 'sha2-256',
   cidVersion: 0,
   shardSplitThreshold: 1000,
-  format: 'dag-pb',
   flush: true,
   mode: null,
   mtime: null
@@ -116,7 +115,6 @@ const addEmptyDir = async (context, childName, emptyDir, parent, trail, options)
     size: emptyDir.node.size,
     cid: emptyDir.cid,
     name: childName,
-    format: options.format,
     hashAlg: options.hashAlg,
     cidVersion: options.cidVersion,
     mode: options.mode,

--- a/src/core/mv.js
+++ b/src/core/mv.js
@@ -10,7 +10,6 @@ const defaultOptions = {
   recursive: false,
   flush: true,
   cidVersion: 0,
-  format: 'dag-pb',
   hashAlg: 'sha2-256',
   shardSplitThreshold: 1000
 }

--- a/src/core/rm.js
+++ b/src/core/rm.js
@@ -16,7 +16,6 @@ const defaultOptions = {
   recursive: false,
   cidVersion: 0,
   hashAlg: 'sha2-256',
-  format: 'dag-pb',
   flush: true
 }
 
@@ -64,7 +63,6 @@ const removePath = async (context, path, options) => {
   } = await removeLink(context, {
     parentCid: parent.cid,
     name: child.name,
-    format: options.format,
     hashAlg: options.hashAlg,
     cidVersion: options.cidVersion,
     flush: options.flush

--- a/src/core/touch.js
+++ b/src/core/touch.js
@@ -18,7 +18,6 @@ const defaultOptions = {
   flush: true,
   shardSplitThreshold: 1000,
   cidVersion: 0,
-  format: 'dag-pb',
   hashAlg: 'sha2-256'
 }
 
@@ -85,7 +84,6 @@ module.exports = (context) => {
       size: node.serialize().length,
       flush: options.flush,
       shardSplitThreshold: options.shardSplitThreshold,
-      format: 'dag-pb',
       hashAlg: 'sha2-256',
       cidVersion
     })

--- a/src/core/utils/add-link.js
+++ b/src/core/utils/add-link.js
@@ -99,11 +99,10 @@ const addToDirectory = async (context, options) => {
   node.mtime = new Date()
   options.parent = new DAGNode(node.marshal(), options.parent.Links)
 
-  const format = mc[options.format.toUpperCase().replace(/-/g, '_')]
   const hashAlg = mh.names[options.hashAlg]
 
   // Persist the new parent DAGNode
-  const cid = await context.ipld.put(options.parent, format, {
+  const cid = await context.ipld.put(options.parent, mc.DAG_PB, {
     cidVersion: options.cidVersion,
     hashAlg,
     onlyHash: !options.flush

--- a/src/core/utils/apply-default-options.js
+++ b/src/core/utils/apply-default-options.js
@@ -17,13 +17,6 @@ module.exports = (options = {}, defaults) => {
     }
   }
 
-  const format = output.format || output.codec
-
-  if (format && isNaN(format)) {
-    output.format = format
-    delete output.codec
-  }
-
   // support legacy go arguments
   if (options.count !== undefined) {
     output.length = options.count

--- a/src/core/utils/create-node.js
+++ b/src/core/utils/create-node.js
@@ -8,7 +8,6 @@ const mc = require('multicodec')
 const mh = require('multihashes')
 
 const createNode = async (context, type, options) => {
-  const format = mc[options.format.toUpperCase().replace(/-/g, '_')]
   const hashAlg = mh.names[options.hashAlg]
   const metadata = new UnixFS({
     type,
@@ -17,7 +16,7 @@ const createNode = async (context, type, options) => {
   })
 
   const node = new DAGNode(metadata.marshal())
-  const cid = await context.ipld.put(node, format, {
+  const cid = await context.ipld.put(node, mc.DAG_PB, {
     cidVersion: options.cidVersion,
     hashAlg,
     onlyHash: !options.flush

--- a/src/core/utils/hamt-utils.js
+++ b/src/core/utils/hamt-utils.js
@@ -24,11 +24,9 @@ const updateHamtDirectory = async (context, links, bucket, options) => {
     mtime: node.mtime
   })
 
-  const format = mc[options.format.toUpperCase().replace(/-/g, '_')]
   const hashAlg = mh.names[options.hashAlg]
-
   const parent = new DAGNode(dir.marshal(), links)
-  const cid = await context.ipld.put(parent, format, {
+  const cid = await context.ipld.put(parent, mc.DAG_PB, {
     cidVersion: options.cidVersion,
     hashAlg,
     onlyHash: !options.flush
@@ -184,7 +182,10 @@ const createShard = async (context, contents, options) => {
     flat: false,
     mtime: options.mtime,
     mode: options.mode
-  }, options)
+  }, {
+    ...options,
+    codec: 'dag-pb'
+  })
 
   for (let i = 0; i < contents.length; i++) {
     await shard._bucket.put(contents[i].name, {

--- a/src/core/utils/remove-link.js
+++ b/src/core/utils/remove-link.js
@@ -48,11 +48,10 @@ const removeLink = async (context, options) => {
 }
 
 const removeFromDirectory = async (context, options) => {
-  const format = mc[options.format.toUpperCase().replace(/-/g, '_')]
   const hashAlg = mh.names[options.hashAlg]
 
   options.parent.rmLink(options.name)
-  const cid = await context.ipld.put(options.parent, format, {
+  const cid = await context.ipld.put(options.parent, mc.DAG_PB, {
     cidVersion: options.cidVersion,
     hashAlg
   })
@@ -79,7 +78,6 @@ const removeFromShardedDirectory = async (context, options) => {
     cid: options.cid,
     size: options.size,
     hashAlg: options.hashAlg,
-    format: options.format,
     cidVersion: options.cidVersion,
     flush: options.flush
   }, options)

--- a/src/core/utils/update-tree.js
+++ b/src/core/utils/update-tree.js
@@ -39,7 +39,6 @@ const updateTree = async (context, trail, options) => {
       size: child.size,
       flush: options.flush,
       shardSplitThreshold: options.shardSplitThreshold,
-      format: options.format,
       hashAlg: options.hashAlg,
       cidVersion: options.cidVersion
     })

--- a/src/core/write.js
+++ b/src/core/write.js
@@ -28,7 +28,6 @@ const defaultOptions = {
   reduceSingleLeafToSelf: false,
   cidVersion: 0,
   hashAlg: 'sha2-256',
-  format: 'dag-pb',
   parents: false, // whether to create intermediate directories if they do not exist
   progress: () => {},
   strategy: 'trickle',
@@ -104,7 +103,6 @@ const updateOrImport = async (context, path, source, destination, options) => {
       size: child.size,
       flush: options.flush,
       shardSplitThreshold: options.shardSplitThreshold,
-      format: options.format,
       hashAlg: options.hashAlg,
       cidVersion: options.cidVersion
     })

--- a/src/http/chmod.js
+++ b/src/http/chmod.js
@@ -13,7 +13,6 @@ const mfsChmod = {
       arg,
       mode,
       recursive,
-      codec,
       hashAlg,
       flush,
       shardSplitThreshold
@@ -21,7 +20,6 @@ const mfsChmod = {
 
     await ipfs.files.chmod(arg, mode, {
       recursive,
-      format: codec,
       hashAlg,
       flush,
       shardSplitThreshold
@@ -40,7 +38,6 @@ const mfsChmod = {
         mode: Joi.string(),
         recursive: Joi.boolean().default(false),
         flush: Joi.boolean().default(true),
-        codec: Joi.string().default('dag-pb'),
         hashAlg: Joi.string().default('sha2-256'),
         shardSplitThreshold: Joi.number().integer().min(0).default(1000)
       })

--- a/src/http/cp.js
+++ b/src/http/cp.js
@@ -13,7 +13,6 @@ const mfsCp = {
       arg,
       parents,
       flush,
-      format,
       hashAlg,
       shardSplitThreshold
     } = request.query
@@ -21,7 +20,6 @@ const mfsCp = {
     const args = arg.concat({
       parents,
       flush,
-      format,
       hashAlg,
       shardSplitThreshold
     })
@@ -40,14 +38,9 @@ const mfsCp = {
         arg: Joi.array().items(Joi.string()).min(2),
         parents: Joi.boolean().default(false),
         flush: Joi.boolean().default(true),
-        format: Joi.string().valid([
-          'dag-pb',
-          'dag-cbor'
-        ]).default('dag-pb'),
         hashAlg: Joi.string().default('sha2-256'),
         shardSplitThreshold: Joi.number().integer().min(0).default(1000)
       })
-        .rename('codec', 'format')
     }
   }
 }

--- a/src/http/mkdir.js
+++ b/src/http/mkdir.js
@@ -16,7 +16,6 @@ const mfsMkdir = {
       mtime,
       mtimeNsecs,
       parents,
-      format,
       hashAlg,
       cidVersion,
       flush,
@@ -27,7 +26,6 @@ const mfsMkdir = {
       mode,
       mtime: parseMtime(mtime, mtimeNsecs),
       parents,
-      format,
       hashAlg,
       cidVersion,
       flush,
@@ -48,10 +46,6 @@ const mfsMkdir = {
         mtime: Joi.number().integer(),
         mtimeNsecs: Joi.number().integer().min(0),
         parents: Joi.boolean().default(false),
-        format: Joi.string().valid([
-          'dag-pb',
-          'dag-cbor'
-        ]).default('dag-pb'),
         hashAlg: Joi.string().default('sha2-256'),
         cidVersion: Joi.number().integer().valid([
           0,

--- a/src/http/mv.js
+++ b/src/http/mv.js
@@ -13,7 +13,6 @@ const mfsMv = {
       arg,
       recursive,
       parents,
-      format,
       hashAlg,
       cidVersion,
       flush,
@@ -25,7 +24,6 @@ const mfsMv = {
       parents,
       cidVersion,
       flush,
-      format,
       hashAlg,
       shardSplitThreshold
     })
@@ -44,10 +42,6 @@ const mfsMv = {
         arg: Joi.array().items(Joi.string()).min(2),
         recursive: Joi.boolean().default(false),
         parents: Joi.boolean().default(false),
-        format: Joi.string().valid([
-          'dag-pb',
-          'dag-cbor'
-        ]).default('dag-pb'),
         hashAlg: Joi.string().default('sha2-256'),
         cidVersion: Joi.number().integer().valid([
           0,

--- a/src/http/touch.js
+++ b/src/http/touch.js
@@ -15,7 +15,6 @@ const mfsTouch = {
       flush,
       shardSplitThreshold,
       cidVersion,
-      format,
       hashAlg,
       mtime,
       mtimeNsecs
@@ -26,7 +25,6 @@ const mfsTouch = {
       flush,
       shardSplitThreshold,
       cidVersion,
-      format,
       hashAlg
     })
 
@@ -42,10 +40,6 @@ const mfsTouch = {
         arg: Joi.string().required(),
         mtime: Joi.number().integer(),
         mtimeNsecs: Joi.number().integer().min(0),
-        format: Joi.string().valid([
-          'dag-pb',
-          'dag-cbor'
-        ]).default('dag-pb'),
         hashAlg: Joi.string().default('sha2-256'),
         cidVersion: Joi.number().integer().valid([
           0,

--- a/src/http/write.js
+++ b/src/http/write.js
@@ -21,7 +21,6 @@ const mfsWrite = {
       reduceSingleLeafToSelf,
       cidVersion,
       hashAlg,
-      format,
       parents,
       progress,
       strategy,
@@ -48,7 +47,6 @@ const mfsWrite = {
           reduceSingleLeafToSelf,
           cidVersion,
           hashAlg,
-          format,
           parents,
           progress,
           strategy,
@@ -84,10 +82,6 @@ const mfsWrite = {
           1
         ]).default(0),
         hashAlg: Joi.string().default('sha2-256'),
-        format: Joi.string().valid([
-          'dag-pb',
-          'dag-cbor'
-        ]).default('dag-pb'),
         parents: Joi.boolean().default(false),
         progress: Joi.func(),
         strategy: Joi.string().valid([

--- a/test/cli/chmod.js
+++ b/test/cli/chmod.js
@@ -8,7 +8,6 @@ const sinon = require('sinon')
 function defaultOptions (modification = {}) {
   const options = {
     recursive: false,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -93,32 +92,6 @@ describe('chmod', () => {
       parseInt(mode, 8),
       defaultOptions({
         flush: false
-      })
-    ])
-  })
-
-  it('should update the mode with a different codec', async () => {
-    await cli(`files chmod ${mode} --codec dag-foo ${path}`, { ipfs })
-
-    expect(ipfs.files.chmod.callCount).to.equal(1)
-    expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
-      path,
-      parseInt(mode, 8),
-      defaultOptions({
-        format: 'dag-foo'
-      })
-    ])
-  })
-
-  it('should update the mode with a different codec (short option)', async () => {
-    await cli(`files chmod ${mode} -c dag-foo ${path}`, { ipfs })
-
-    expect(ipfs.files.chmod.callCount).to.equal(1)
-    expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
-      path,
-      parseInt(mode, 8),
-      defaultOptions({
-        format: 'dag-foo'
       })
     ])
   })

--- a/test/cli/cp.js
+++ b/test/cli/cp.js
@@ -8,7 +8,6 @@ const sinon = require('sinon')
 function defaultOptions (modification = {}) {
   const options = {
     parents: false,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -67,32 +66,6 @@ describe('cp', () => {
       dest,
       defaultOptions({
         parents: true
-      })
-    ])
-  })
-
-  it('should copy files with a different codec', async () => {
-    await cli(`files cp --codec dag-foo ${source} ${dest}`, { ipfs })
-
-    expect(ipfs.files.cp.callCount).to.equal(1)
-    expect(ipfs.files.cp.getCall(0).args).to.deep.equal([
-      source,
-      dest,
-      defaultOptions({
-        format: 'dag-foo'
-      })
-    ])
-  })
-
-  it('should copy files with a different codec (short option)', async () => {
-    await cli(`files cp -c dag-foo ${source} ${dest}`, { ipfs })
-
-    expect(ipfs.files.cp.callCount).to.equal(1)
-    expect(ipfs.files.cp.getCall(0).args).to.deep.equal([
-      source,
-      dest,
-      defaultOptions({
-        format: 'dag-foo'
       })
     ])
   })

--- a/test/cli/mkdir.js
+++ b/test/cli/mkdir.js
@@ -10,7 +10,6 @@ function defaultOptions (modification = {}) {
   const options = {
     parents: false,
     cidVersion: 0,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000,
@@ -95,30 +94,6 @@ describe('mkdir', () => {
       path,
       defaultOptions({
         cidVersion: 5
-      })
-    ])
-  })
-
-  it('should make a directory with a different codec', async () => {
-    await cli(`files mkdir --codec dag-foo ${path}`, { ipfs })
-
-    expect(ipfs.files.mkdir.callCount).to.equal(1)
-    expect(ipfs.files.mkdir.getCall(0).args).to.deep.equal([
-      path,
-      defaultOptions({
-        format: 'dag-foo'
-      })
-    ])
-  })
-
-  it('should make a directory with a different codec (short option)', async () => {
-    await cli(`files mkdir -c dag-foo ${path}`, { ipfs })
-
-    expect(ipfs.files.mkdir.callCount).to.equal(1)
-    expect(ipfs.files.mkdir.getCall(0).args).to.deep.equal([
-      path,
-      defaultOptions({
-        format: 'dag-foo'
       })
     ])
   })

--- a/test/cli/mv.js
+++ b/test/cli/mv.js
@@ -11,7 +11,6 @@ function defaultOptions (modification = {}) {
     parents: false,
     recursive: false,
     cidVersion: 0,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -126,32 +125,6 @@ describe('mv', () => {
       dest,
       defaultOptions({
         cidVersion: 5
-      })
-    ])
-  })
-
-  it('should make a directory with a different codec', async () => {
-    await cli(`files mv --codec dag-foo ${source} ${dest}`, { ipfs })
-
-    expect(ipfs.files.mv.callCount).to.equal(1)
-    expect(ipfs.files.mv.getCall(0).args).to.deep.equal([
-      source,
-      dest,
-      defaultOptions({
-        format: 'dag-foo'
-      })
-    ])
-  })
-
-  it('should make a directory with a different codec (short option)', async () => {
-    await cli(`files mv -c dag-foo ${source} ${dest}`, { ipfs })
-
-    expect(ipfs.files.mv.callCount).to.equal(1)
-    expect(ipfs.files.mv.getCall(0).args).to.deep.equal([
-      source,
-      dest,
-      defaultOptions({
-        format: 'dag-foo'
       })
     ])
   })

--- a/test/cli/touch.js
+++ b/test/cli/touch.js
@@ -10,7 +10,6 @@ function defaultOptions (modification = {}) {
   const options = {
     mtime: null,
     cidVersion: 0,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -74,32 +73,6 @@ describe('touch', () => {
       defaultOptions({
         mtime,
         flush: false
-      })
-    ])
-  })
-
-  it('should update the mtime with a different codec', async () => {
-    await cli(`files touch -m ${mtime.getTime() / 1000} --codec dag-foo ${path}`, { ipfs })
-
-    expect(ipfs.files.touch.callCount).to.equal(1)
-    expect(ipfs.files.touch.getCall(0).args).to.deep.equal([
-      path,
-      defaultOptions({
-        mtime,
-        format: 'dag-foo'
-      })
-    ])
-  })
-
-  it('should update the mtime with a different codec (short option)', async () => {
-    await cli(`files touch -m ${mtime.getTime() / 1000} -c dag-foo ${path}`, { ipfs })
-
-    expect(ipfs.files.touch.callCount).to.equal(1)
-    expect(ipfs.files.touch.getCall(0).args).to.deep.equal([
-      path,
-      defaultOptions({
-        mtime,
-        format: 'dag-foo'
       })
     ])
   })

--- a/test/cli/write.js
+++ b/test/cli/write.js
@@ -16,7 +16,6 @@ function defaultOptions (modification = {}) {
     reduceSingleLeafToSelf: false,
     cidVersion: 0,
     hashAlg: 'sha2-256',
-    format: 'dag-pb',
     parents: false,
     progress: undefined,
     strategy: 'balanced',
@@ -344,36 +343,6 @@ describe('write', () => {
       stdin,
       defaultOptions({
         cidVersion: 5
-      })
-    ])
-  })
-
-  it('should write to a file with a specified codec', async () => {
-    const path = '/foo'
-
-    await cli(`files write --codec dag-foo ${path}`, { ipfs, getStdin })
-
-    expect(ipfs.files.write.callCount).to.equal(1)
-    expect(ipfs.files.write.getCall(0).args).to.deep.equal([
-      path,
-      stdin,
-      defaultOptions({
-        format: 'dag-foo'
-      })
-    ])
-  })
-
-  it('should write to a file with a specified codec (short option)', async () => {
-    const path = '/foo'
-
-    await cli(`files write -c dag-foo ${path}`, { ipfs, getStdin })
-
-    expect(ipfs.files.write.callCount).to.equal(1)
-    expect(ipfs.files.write.getCall(0).args).to.deep.equal([
-      path,
-      stdin,
-      defaultOptions({
-        format: 'dag-foo'
       })
     ])
   })

--- a/test/helpers/http.js
+++ b/test/helpers/http.js
@@ -8,7 +8,9 @@ module.exports = (request, { ipfs }) => {
   server.app.ipfs = ipfs
 
   for (const key in routes) {
-    server.route(routes[key])
+    if (Object.prototype.hasOwnProperty.call(routes, key)) {
+      server.route(routes[key])
+    }
   }
 
   return server.inject(request)

--- a/test/http/chmod.js
+++ b/test/http/chmod.js
@@ -8,7 +8,6 @@ const sinon = require('sinon')
 function defaultOptions (modification = {}) {
   const options = {
     recursive: false,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -76,22 +75,6 @@ describe('chmod', () => {
       mode,
       defaultOptions({
         flush: false
-      })
-    ])
-  })
-
-  it('should update the mode a different codec', async () => {
-    await http({
-      method: 'POST',
-      url: `/api/v0/files/chmod?arg=${path}&mode=${mode}&codec=dag-foo`
-    }, { ipfs })
-
-    expect(ipfs.files.chmod.callCount).to.equal(1)
-    expect(ipfs.files.chmod.getCall(0).args).to.deep.equal([
-      path,
-      mode,
-      defaultOptions({
-        format: 'dag-foo'
       })
     ])
   })

--- a/test/http/cp.js
+++ b/test/http/cp.js
@@ -8,7 +8,6 @@ const sinon = require('sinon')
 function defaultOptions (modification = {}) {
   const options = {
     parents: false,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -60,22 +59,6 @@ describe('cp', () => () => {
       dest,
       defaultOptions({
         parents: true
-      })
-    ])
-  })
-
-  it('should copy files with a different codec', async () => {
-    await http({
-      method: 'POST',
-      url: `/api/v0/files/cp?arg=${source}&arg=${dest}&codec=dag-cbor`
-    }, { ipfs })
-
-    expect(ipfs.files.cp.callCount).to.equal(1)
-    expect(ipfs.files.cp.getCall(0).args).to.deep.equal([
-      source,
-      dest,
-      defaultOptions({
-        format: 'dag-cbor'
       })
     ])
   })

--- a/test/http/mkdir.js
+++ b/test/http/mkdir.js
@@ -9,7 +9,6 @@ function defaultOptions (modification = {}) {
   const options = {
     parents: false,
     cidVersion: 0,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000,
@@ -75,21 +74,6 @@ describe('mkdir', () => {
       path,
       defaultOptions({
         cidVersion: 1
-      })
-    ])
-  })
-
-  it('should make a directory with a different codec', async () => {
-    await http({
-      method: 'POST',
-      url: `/api/v0/files/mkdir?arg=${path}&format=dag-cbor`
-    }, { ipfs })
-
-    expect(ipfs.files.mkdir.callCount).to.equal(1)
-    expect(ipfs.files.mkdir.getCall(0).args).to.deep.equal([
-      path,
-      defaultOptions({
-        format: 'dag-cbor'
       })
     ])
   })

--- a/test/http/mv.js
+++ b/test/http/mv.js
@@ -10,7 +10,6 @@ function defaultOptions (modification = {}) {
     parents: false,
     recursive: false,
     cidVersion: 0,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -94,22 +93,6 @@ describe('mv', () => {
       dest,
       defaultOptions({
         cidVersion: 1
-      })
-    ])
-  })
-
-  it('should make a directory with a different codec', async () => {
-    await http({
-      method: 'POST',
-      url: `/api/v0/files/mv?arg=${source}&arg=${dest}&format=dag-cbor`
-    }, { ipfs })
-
-    expect(ipfs.files.mv.callCount).to.equal(1)
-    expect(ipfs.files.mv.getCall(0).args).to.deep.equal([
-      source,
-      dest,
-      defaultOptions({
-        format: 'dag-cbor'
       })
     ])
   })

--- a/test/http/touch.js
+++ b/test/http/touch.js
@@ -9,7 +9,6 @@ function defaultOptions (modification = {}) {
   const options = {
     mtime: null,
     cidVersion: 0,
-    format: 'dag-pb',
     hashAlg: 'sha2-256',
     flush: true,
     shardSplitThreshold: 1000
@@ -66,24 +65,6 @@ describe('touch', () => {
           secs: 1000
         },
         flush: false
-      })
-    ])
-  })
-
-  it('should update the mtime with a different codec', async () => {
-    await http({
-      method: 'POST',
-      url: `/api/v0/files/touch?arg=${path}&mtime=${mtime.getTime() / 1000}&format=dag-pb`
-    }, { ipfs })
-
-    expect(ipfs.files.touch.callCount).to.equal(1)
-    expect(ipfs.files.touch.getCall(0).args).to.deep.equal([
-      path,
-      defaultOptions({
-        mtime: {
-          secs: 1000
-        },
-        format: 'dag-pb'
       })
     ])
   })

--- a/test/http/write.js
+++ b/test/http/write.js
@@ -17,7 +17,6 @@ function defaultOptions (modification = {}) {
     reduceSingleLeafToSelf: false,
     cidVersion: 0,
     hashAlg: 'sha2-256',
-    format: 'dag-pb',
     parents: false,
     progress: undefined,
     strategy: 'trickle',
@@ -226,21 +225,6 @@ describe('write', () => {
     expect(ipfs.files.write.getCall(0)).to.have.nested.property('args[0]', path)
     expect(ipfs.files.write.getCall(0)).to.have.nested.deep.property('args[2]', defaultOptions({
       cidVersion: 1
-    }))
-    expect(content).to.equal('hello world')
-  })
-
-  it('should write to a file with a specified codec', async () => {
-    await http({
-      method: 'POST',
-      url: `/api/v0/files/write?arg=${path}&format=dag-cbor`,
-      ...await send('hello world')
-    }, { ipfs })
-
-    expect(ipfs.files.write.callCount).to.equal(1)
-    expect(ipfs.files.write.getCall(0)).to.have.nested.property('args[0]', path)
-    expect(ipfs.files.write.getCall(0)).to.have.nested.deep.property('args[2]', defaultOptions({
-      format: 'dag-cbor'
     }))
     expect(content).to.equal('hello world')
   })


### PR DESCRIPTION
IPFS is all `dag-pb` yet we allow passing `dag-cbor` as the format of IPLD node to use.  This is likely to break anything that uses it as tools expect IPFS stuff to be `dag-pb`, possibly with `raw` leaves.

Closes #67

BREAKING CHANGE:

`format` and/or `codec` option has been removed from the CLI, the HTTP API and the core API.