### PR TITLE
fix: allow writing starting at offset beyond file length

### DIFF
--- a/src/core/write.js
+++ b/src/core/write.js
@@ -128,7 +128,7 @@ const write = async (context, source, destination, options) => {
 
   // pad start of file if necessary
   if (options.offset > 0) {
-    if (destination.unixfs && destination.unixfs.fileSize() > options.offset) {
+    if (destination.unixfs) {
       log(`Writing first ${options.offset} bytes of original file`)
 
       sources.push(
@@ -139,6 +139,15 @@ const write = async (context, source, destination, options) => {
           })
         }
       )
+
+      if (destination.unixfs.fileSize() < options.offset) {
+        const extra = options.offset - destination.unixfs.fileSize()
+
+        log(`Writing zeros for extra ${extra} bytes`)
+        sources.push(
+          asyncZeroes(extra)
+        )
+      }
     } else {
       log(`Writing zeros for first ${options.offset} bytes`)
       sources.push(

--- a/test/core/write.js
+++ b/test/core/write.js
@@ -373,11 +373,13 @@ describe('write', () => {
       const stats = await mfs.stat(path)
       expect(stats.size).to.equal(newContent.length + offset)
 
-      const buffer = Buffer.concat(await all(mfs.read(path, {
-        offset: offset - 5
-      })))
+      const buffer = Buffer.concat(await all(mfs.read(path)))
 
-      expect(buffer).to.deep.equal(Buffer.concat([Buffer.from([0, 0, 0, 0, 0]), newContent]))
+      if (content[Symbol.asyncIterator]) {
+        content = Buffer.concat(await all(content))
+      }
+
+      expect(buffer).to.deep.equal(Buffer.concat([content, Buffer.from([0, 0, 0, 0, 0]), newContent]))
     })
   })
 


### PR DESCRIPTION
There was a test for this but it didn't check the contents of the entire file, only starting from the difference between the offset and the file length.  Oops.

Fixes #53